### PR TITLE
README: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For third-party systems, I am using Debian 12, but you can find some manuals for
 - TrueNAS: see [#13](https://github.com/miskcoo/ugreen_dx4600_leds_controller/issues/13) (and maybe [here](https://github.com/miskcoo/ugreen_dx4600_leds_controller/tree/truenas-build/build-scripts/truenas)) for how to build the module, and [here](https://gist.github.com/Kerryliu/c380bb6b3b69be5671105fc23e19b7e8) for a script using the cli tool; [here](https://github.com/miskcoo/ugreen_dx4600_leds_controller/tree/gh-actions/build-scripts/truenas/build) for pre-build drivers 
 - unRAID: there is a [plugin](https://forums.unraid.net/topic/168423-ugreen-nas-led-control/); see also [this repo](https://github.com/ich777/unraid-ugreenleds-driver/tree/master/source/usr/bin)
 - Proxmox: you need to use the cli tool in Proxmox, not in a VM
-- Debian: see [the section below](https://github.com/miskcoo/ugreen_dx4600_leds_controller?tab=readme-ov-file#start-at-boot-for-debian-12)
+- Debian: see [the section below](https://github.com/miskcoo/ugreen_dx4600_leds_controller#start-at-boot-for-debian-12)
 
 Below is an example:
 


### PR DESCRIPTION
The link for Debian was using an old schema not supported on the mobile app.