### PR TITLE
Make build more flexible and complete.

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -4,8 +4,10 @@ ccflags-y := -std=gnu11
 
 # if KERNELRELEASE isn't set, i.e. not being built w/ DMKS, then use uname -r
 KERNELRELEASE ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KERNELRELEASE)/build
 
 all:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) modules
+	make -C $(KDIR) M=$(PWD) modules
+
 clean:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(PWD) clean
+	make -C $(KDIR) M=$(PWD) clean

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -5,9 +5,13 @@ ccflags-y := -std=gnu11
 # if KERNELRELEASE isn't set, i.e. not being built w/ DMKS, then use uname -r
 KERNELRELEASE ?= $(shell uname -r)
 KDIR ?= /lib/modules/$(KERNELRELEASE)/build
+INSTALL_MOD_PATH ?= /
 
 all:
 	make -C $(KDIR) M=$(PWD) modules
 
 clean:
 	make -C $(KDIR) M=$(PWD) clean
+
+install:
+	make -C $(KDIR) M=$(PWD) INSTALL_MOD_PATH=$(INSTALL_MOD_PATH) modules_install


### PR DESCRIPTION
Two individual changes here, one per commit.

1. Allow specifying kernel directory when building
2. Add an `install` target to the Makefile.

I was packaging this module for nixos, where the kernel isn't installed under `/lib`, and was supporting these changes as part of that process.