### PR TITLE
Add support for ledtrig-blkdev

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -109,6 +109,7 @@ BRIGHTNESS_DISK_LEDS=${BRIGHTNESS_DISK_LEDS:="255"}
 
 
 { lsmod | grep ledtrig_oneshot > /dev/null; } || { modprobe -v ledtrig_oneshot && sleep 2; }
+{ lsmod | grep ledtrig_blkdev > /dev/null; } || modprobe -v ledtrig-blkdev 2> /dev/null
 
 function disk_enumerating_string() {
     if [[ $MAPPING_METHOD == ata ]]; then
@@ -143,9 +144,15 @@ done <<< "$(disk_enumerating_string)"
 # initialize LEDs
 declare -A dev_to_led_map
 for i in "${!led_map[@]}"; do
-    led=${led_map[i]} 
+    led=${led_map[i]}
     if [[ -d /sys/class/leds/$led ]]; then
-        echo oneshot > /sys/class/leds/$led/trigger
+        # check if ledtrig-blkdev is available
+        if grep -q blkdev /sys/class/leds/$led/trigger; then
+            echo blkdev > /sys/class/leds/$led/trigger
+            CHECK_DISKIO=false
+        else
+            echo oneshot > /sys/class/leds/$led/trigger
+        fi
         echo 1 > /sys/class/leds/$led/invert
         echo 100 > /sys/class/leds/$led/delay_on
         echo 100 > /sys/class/leds/$led/delay_off
@@ -155,13 +162,17 @@ for i in "${!led_map[@]}"; do
         # find corresponding device
         _tmp_str=${MAPPING_METHOD}_map[@]
         _tmp_arr=(${!_tmp_str})
-        
+
         if [[ -v "dev_map[${_tmp_arr[i]}]" ]]; then
             dev=${dev_map[${_tmp_arr[i]}]}
 
             if [[ -f /sys/class/block/${dev}/stat ]]; then
                 devices[$led]=${dev}
                 dev_to_led_map[$dev]=$led
+                # link led to the device if ledtrig-blkdev is loaded
+                if [[ -f /sys/class/leds/$led/link_dev_by_path ]]; then
+                    echo "/dev/${dev}" > /sys/class/leds/$led/link_dev_by_path
+                fi
             else
                 # turn off the led if no disk installed on this slot
                 echo 0 > /sys/class/leds/$led/brightness
@@ -226,8 +237,11 @@ if [ "$CHECK_ZPOOL" = true ]; then
                     fi
 
                     if [[ "${zpool_dev_state}" != "ONLINE" ]]; then
+                        if [[ -f /sys/class/leds/$led/unlink_dev_by_name ]]; then
+                            echo $zpool_dev_name > /sys/class/leds/$led/unlink_dev_by_name
+                        fi
                         echo "$COLOR_ZPOOL_FAIL" > /sys/class/leds/$led/color
-                        echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
+                        echo Disk failure detected on /dev/$zpool_dev_name at $(date +%Y-%m-%d' '%H:%M:%S)
                     fi
 
                     # ==== To recover from an error, you should restart the script ====
@@ -284,6 +298,9 @@ fi
             fi
 
             if [[ ! -f /sys/class/block/${dev}/stat ]]; then
+                if [[ -f /sys/class/leds/$led/unlink_dev_by_name ]]; then
+                    echo ${dev} > /sys/class/leds/$led/unlink_dev_by_name
+                fi
                 echo "$COLOR_DISK_UNAVAIL" > /sys/class/leds/$led/color 2>/dev/null
                 echo Disk /dev/$dev went offline at $(date +%Y-%m-%d' '%H:%M:%S)
                 continue
@@ -294,21 +311,25 @@ fi
 ) &
 disk_online_check_pid=$!
 
-# monitor disk activities
+# monitor disk activities when ledtrig-blkdev is not available
 declare -A diskio_data_rw
-while true; do
-    for led in "${!devices[@]}"; do
+if [ "$CHECK_DISKIO" != "false" ]; then
+    while true; do
+        for led in "${!devices[@]}"; do
 
-        # if $dev does not exist, diskio_new_rw="", which will be safe
-        diskio_new_rw="$(cat /sys/block/${devices[$led]}/stat 2>/dev/null)"
+            # if $dev does not exist, diskio_new_rw="", which will be safe
+            diskio_new_rw="$(cat /sys/block/${devices[$led]}/stat 2>/dev/null)"
 
-        if [ "${diskio_data_rw[$led]}" != "${diskio_new_rw}" ]; then
-            echo 1 > /sys/class/leds/$led/shot
-        fi
+            if [ "${diskio_data_rw[$led]}" != "${diskio_new_rw}" ]; then
+                echo 1 > /sys/class/leds/$led/shot
+            fi
 
-        diskio_data_rw[$led]=$diskio_new_rw
+            diskio_data_rw[$led]=$diskio_new_rw
+        done
+
+        sleep ${LED_REFRESH_INTERVAL}s
+
     done
+fi
 
-    sleep ${LED_REFRESH_INTERVAL}s
-
-done
+wait $disk_online_check_pid


### PR DESCRIPTION
Hi,

ugreen-diskiomon currently uses 0.1sec bash loop to check for disk statistics and blink leds.
This uses about 0,7%-1% CPU on my DXP6800Pro which is not insignificant.

I was searching for solutions and found that there is a led trigger written for this kind of usage: blkdev. It allows to link a block device to the trigger and blink on activity. Unfortunately it does not seem like it will be merged as the maintainer does not like the sysfs interface of linking/unlinking devices.

I wrote a proof of concept patch for diskiomon and tested the results. The CPU activity with ledtrig-blkdev being used falls down to 0%. Powertop shows ~1050 wakeups with default loop compared to <200 with blkdev. The system spends ~85% in C3 compared to 25% using default functionality.

What do you think? I've retained the default functionality in the script if the module is not available.
But maybe we can include it as well? We're building one module, we might as well build two...

The patch is not finalized; ledtrig-blkdev does seem to support invert, so the leds turn on activity instead of turning off.
I could probably add invert to the module without much trouble. I also haven't tested all the edge cases as well (since inversion is not supported, trigger should be changed on disk failure in order for the led to be on), so there is still some work to be done if this is to be included. Also haven't tested ZFS at all and I think there's a minor bug there:

"Disk failure detected on /dev/$dev"

...there is no $dev defined inside that function. I suppose this should be $zpool_dev_name which I have also used to unlink the led?

I've built the module for RHEL8 and 9 and can include the SPEC for kmod rpm as well if we will include the module itself.