### PR TITLE
Add support for disk standby.

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -103,6 +103,7 @@ CHECK_DISK_ONLINE_INTERVAL=${CHECK_DISK_ONLINE_INTERVAL:=5}
 
 COLOR_DISK_HEALTH=${COLOR_DISK_HEALTH:="255 255 255"}
 COLOR_DISK_UNAVAIL=${COLOR_DISK_UNAVAIL:="255 0 0"}
+COLOR_DISK_STANDBY=${COLOR_DISK_STANDBY:="0 0 255"}
 COLOR_ZPOOL_FAIL=${COLOR_ZPOOL_FAIL:="255 0 0"}
 COLOR_SMART_FAIL=${COLOR_SMART_FAIL:="255 0 0"}
 BRIGHTNESS_DISK_LEDS=${BRIGHTNESS_DISK_LEDS:="255"}
@@ -261,7 +262,12 @@ if [ "$CHECK_SMART" = true ]; then
 
             dev=${devices[$led]}
 
-            if [[ -z $(smartctl -H /dev/${dev} | grep PASSED) ]]; then
+            /usr/sbin/smartctl -H /dev/${dev} -n standby,1 &> /dev/null
+            RET=$?
+
+            if [[ $RET -eq 1 ]]; then
+                echo "$COLOR_DISK_STANDBY" > /sys/class/leds/$led/color
+            elif [[ $RET -gt 1 ]]; then
                 echo "$COLOR_SMART_FAIL" > /sys/class/leds/$led/color
                 echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
                 continue
@@ -279,7 +285,22 @@ fi
         for led in "${!devices[@]}"; do
             dev=${devices[$led]}
 
-            if [[ "$(cat /sys/class/leds/$led/color)" != "$COLOR_DISK_HEALTH" ]]; then
+            led_color=$(cat /sys/class/leds/$led/color)
+
+            if [[ "$led_color" == "$COLOR_DISK_STANDBY" ]]; then
+                # Check if disk is still in standby
+                /usr/sbin/smartctl -H /dev/${dev} -n standby,1 &> /dev/null
+                RET=$?
+
+                if [[ $RET -eq 0 ]]; then
+                    led_color="$COLOR_DISK_HEALTH"
+                    echo $led_color > /sys/class/leds/$led/color
+                elif [[ $RET -gt 1 ]]; then
+                    echo "$COLOR_SMART_FAIL" > /sys/class/leds/$led/color
+                    echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
+                    continue
+                fi
+            elif [[ "$led_color" != "$COLOR_DISK_HEALTH" ]]; then
                 continue;
             fi
 

--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -42,6 +42,9 @@ COLOR_DISK_HEALTH="255 255 255"
 # color of an unavailable disk (default: 255 0 0)
 COLOR_DISK_UNAVAIL="255 0 0"
 
+# color of a disk in standby mode (default: 0 0 255)
+COLOR_DISK_STANDBY="0 0 255"
+
 # color of a failed zpool device (default: 255 0 0)
 COLOR_ZPOOL_FAIL="255 0 0"
 


### PR DESCRIPTION
Running `smartctl -H` will wake a disk in standby.
Avoid this by passing `-n standby` to `smartctl` and at the same time turn led color to `$COLOR_DISK_STANDBY` (blue by default).
Led is reset in `check disk online status` loop.

This might delay led turning blue up to smartctl interval time (5 min), however I wanted to avoid running smartctl more frequently. For disks in standby, status is rechecked in `check disk online status` loop as this would not really call into smart health status. Led is reset if disk is woken or failed. This reacts faster and usually the led is reset before the disk is completely spun up.

An alternative would be I suppose to use `hdparm` to check for power status in disk online loop and react faster but I did not want to bring new dependencies.

Disks would probably still be woken if put into `sleep` mode as that reqires interface reset before getting any response from the disk. Users should just use `standby` instead.

I've also changed smartctl check, it's now checking for return code (which would indicate any failure) and used return status 1 as disk in standby (which is originally used for `Command line did not parse.` but hopefully that should not happen).