### PR TITLE
Add an optional compiled disk activities monitor to reduce the CPU usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ Please see `scripts/ugreen-leds.conf` for an example.
   systemctl enable ugreen-diskiomon
   ```
 
+- (_Optional_) To reduce the CPU usage of blinking LEDs when disks are active, you can enter the `scripts` directory and do the following things:
+  ```bash
+  # compile the disk activities monitor
+  g++ -std=c++17 -O2 blink-disk.cpp -o ugreen-blink-disk
+
+  # copy the binary file (the path can be changed, see BLINK_MON_PATH in ugreen-leds.conf)
+  cp ugreen-blink-disk /usr/bin
+  ```
+
 ## Disk Mapping
 
 To make the disk LEDs useful, we should map the disk LEDs to correct disk slots. First of all, we should highlight that using `/dev/sdX` is never a smart idea, as it may change at every boot.  

--- a/scripts/blink-disk.cpp
+++ b/scripts/blink-disk.cpp
@@ -1,0 +1,46 @@
+#include <fstream>
+#include <thread>
+#include <iostream>
+#include <string>
+#include <chrono>
+
+int main(int argc, char *argv[]) {
+    if (argc < 4) {
+        std::cerr << "Usage: " << argv[0] << " <block device> <led device> <sleep time (in second)>\n";
+        return 1;
+    }
+
+    std::string block_device = argv[1];
+    std::string led_device = argv[2];
+    int sleep_time_ms = int(std::stod(argv[3]) * 1000);
+
+    std::string block_device_stat = "/sys/block/" + block_device + "/stat";
+    std::string led_device_shot = "/sys/class/leds/" + led_device + "/shot";
+
+    for (std::string line, old_line; ; old_line = line) {
+
+        std::ifstream stat_file(block_device_stat);
+        if (!stat_file.is_open()) {
+            std::cerr << "Failed to open " << block_device_stat << "\n";
+            return 1;
+        }
+
+        std::getline(stat_file, line);
+        stat_file.close();
+
+        if (line != old_line) {
+            std::ofstream led_file(led_device_shot);
+            if (!led_file.is_open()) {
+                std::cerr << "Failed to open " << led_device_shot << "\n";
+                return 1;
+            }
+
+            led_file << "1";
+            led_file.close();
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time_ms));
+    }
+
+    return 0;
+}

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -227,7 +227,7 @@ if [ "$CHECK_ZPOOL" = true ]; then
 
                     if [[ "${zpool_dev_state}" != "ONLINE" ]]; then
                         echo "$COLOR_ZPOOL_FAIL" > /sys/class/leds/$led/color
-                        echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
+                        echo Disk failure detected on /dev/$zpool_dev_name at $(date +%Y-%m-%d' '%H:%M:%S)
                     fi
 
                     # ==== To recover from an error, you should restart the script ====

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -295,20 +295,37 @@ fi
 disk_online_check_pid=$!
 
 # monitor disk activities
-declare -A diskio_data_rw
-while true; do
+BLINK_MON_PATH=${BLINK_MON_PATH:=/usr/bin/ugreen-blink-disk}
+if [ -f "${BLINK_MON_PATH}" ]; then
+
+    declare -A blinkmon_pids
     for led in "${!devices[@]}"; do
 
-        # if $dev does not exist, diskio_new_rw="", which will be safe
-        diskio_new_rw="$(cat /sys/block/${devices[$led]}/stat 2>/dev/null)"
-
-        if [ "${diskio_data_rw[$led]}" != "${diskio_new_rw}" ]; then
-            echo 1 > /sys/class/leds/$led/shot
-        fi
-
-        diskio_data_rw[$led]=$diskio_new_rw
+        "${BLINK_MON_PATH}" ${devices[$led]} $led ${LED_REFRESH_INTERVAL} &
+        blinkmon_pids[$led]=$!
     done
 
-    sleep ${LED_REFRESH_INTERVAL}s
+    # wait for all pids
+    for pid in ${blinkmon_pids[*]}; do
+        wait $pid
+    done
 
-done
+else 
+    declare -A diskio_data_rw
+    while true; do
+        for led in "${!devices[@]}"; do
+
+            # if $dev does not exist, diskio_new_rw="", which will be safe
+            diskio_new_rw="$(cat /sys/block/${devices[$led]}/stat 2>/dev/null)"
+
+            if [ "${diskio_data_rw[$led]}" != "${diskio_new_rw}" ]; then
+                echo 1 > /sys/class/leds/$led/shot
+            fi
+
+            diskio_data_rw[$led]=$diskio_new_rw
+        done
+
+        sleep ${LED_REFRESH_INTERVAL}s
+
+    done
+fi

--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -298,17 +298,14 @@ disk_online_check_pid=$!
 BLINK_MON_PATH=${BLINK_MON_PATH:=/usr/bin/ugreen-blink-disk}
 if [ -f "${BLINK_MON_PATH}" ]; then
 
-    declare -A blinkmon_pids
-    for led in "${!devices[@]}"; do
+    diskiomon_parameters() {
+        echo ${LED_REFRESH_INTERVAL}
+        for led in "${!devices[@]}"; do
+            echo ${devices[$led]} $led
+        done
+    }
 
-        "${BLINK_MON_PATH}" ${devices[$led]} $led ${LED_REFRESH_INTERVAL} &
-        blinkmon_pids[$led]=$!
-    done
-
-    # wait for all pids
-    for pid in ${blinkmon_pids[*]}; do
-        wait $pid
-    done
+    ${BLINK_MON_PATH} $(diskiomon_parameters)
 
 else 
     declare -A diskio_data_rw

--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -20,6 +20,9 @@
 #           and fill the DISK_SERIAL array below (see the comments therein).
 MAPPING_METHOD=ata
 
+# The path of the compiled diskio monitor (OPTIONAL) 
+BLINK_MON_PATH=/usr/bin/ugreen-blink-disk
+
 # The serial numbers of disks (used only when MAPPING_METHOD=serial)
 # You need to record them before inserting to your NAS, and the corresponding disk slots.
 # If you have 4 disks, with serial numbers: SN1 SN2 SN3 SN4, 


### PR DESCRIPTION
This is an optional feature to reduce the CPU usage when monitoring the disk activities. The current bash implementation gives too many forks and use around 1% CPU times, which is also reported in #8, #10 and #34.

This PR replaces the bash version to a C++ version, and you need to do the following to enable it:

```
# compile the disk activities monitor
g++ -std=c++17 -O2 scripts/blink-disk.cpp -o ugreen-blink-disk

# copy the binary file (the path can be changed, see BLINK_MON_PATH in ugreen-leds.conf)
cp ugreen-blink-disk /usr/bin

# copy the new script and restart the service
cp scripts/ugreen-diskiomon /usr/bin
systemctl restart ugreen-diskiomon
```

See #34 for further discussions and a test of the performance.