### PR TITLE
Update ugreen-diskiomon to ignore smartctl non-critical return codes

### DIFF
--- a/scripts/ugreen-diskiomon
+++ b/scripts/ugreen-diskiomon
@@ -277,7 +277,9 @@ if [ "$CHECK_SMART" = true ]; then
             /usr/sbin/smartctl -H /dev/${dev} -n standby,1 &> /dev/null
             RET=$?
 
-            if [[ $RET -gt 1 ]]; then
+            # check return code for critical errors (any bit set except bit 5)
+            # possible return bits set: https://invent.kde.org/system/kpmcore/-/merge_requests/28
+            if (( $RET & ~32 )); then
                 echo "$COLOR_SMART_FAIL" > /sys/class/leds/$led/color
                 echo Disk failure detected on /dev/$dev at $(date +%Y-%m-%d' '%H:%M:%S)
                 continue


### PR DESCRIPTION
Smartctl will also return non-zero if it detected past errors even when currently no other errors are observed. It will set up to 8 bits to indicate the differen types of observed results, where bit 5 does not indicate a _current_ error: `SMART status check returned "DISK OK" but some attributes have been at or below threshold in the past.`

The change ignores bit 5 (= 32) when checking the exit code.

Future improvements could detect other bits to color the leds differently depending on the type of error (f.e. bit 4 might indicate a future problem and could turn the led orange instead of red)

Fixes https://github.com/miskcoo/ugreen_leds_controller/issues/56