### PR TITLE
Add support for setting power LED via systemctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,13 @@ Please see `scripts/ugreen-leds.conf` for an example.
   # change enp2s0 to the network device you want to monitor
   systemctl start ugreen-netdevmon@enp2s0 
   systemctl start ugreen-diskiomon
+  systemctl start ugreen-power-led
   
   # if you confirm that everything works well, 
   # run the command below to make the service start at boot
   systemctl enable ugreen-netdevmon@enp2s0 
   systemctl enable ugreen-diskiomon
+  systemctl enable ugreen-power-led
   ```
 
 - (_Optional_) To reduce the CPU usage of blinking LEDs when disks are active, you can enter the `scripts` directory and do the following things:

--- a/scripts/systemd/ugreen-power-led.service
+++ b/scripts/systemd/ugreen-power-led.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=UGREEN LEDs daemon for configuring power LED
+After=ugreen-probe-leds.service
+Requires=ugreen-probe-leds.service
+
+[Service]
+ExecStart=/usr/bin/ugreen-power-led
+StandardOutput=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/systemd/ugreen-power-led.service
+++ b/scripts/systemd/ugreen-power-led.service
@@ -4,7 +4,9 @@ After=ugreen-probe-leds.service
 Requires=ugreen-probe-leds.service
 
 [Service]
+Type=oneshot
 ExecStart=/usr/bin/ugreen-power-led
+RemainAfterExit=true
 StandardOutput=journal
 
 [Install]

--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -110,3 +110,17 @@ COLOR_NETDEV_LINK_10000="255 255 255"
 
 # color of the netdev when unable to ping the gateway
 COLOR_NETDEV_GATEWAY_UNREACHABLE="255 0 0"
+
+# =========== parameters for power LED =========== 
+
+# Blink settings for the power LED
+# * none: no blinking (default)
+# * breath <delay_on> <delay_off>: breathing blink
+# * blink <delay_on> <delay_off>: blinking
+BLINK_TYPE_POWER="none"
+
+# brighness of the power LED (default: 255)
+BRIGHTNESS_POWER=255
+
+# color of the power LED (default: 255 255 255)
+COLOR_POWER="255 255 255"

--- a/scripts/ugreen-power-led
+++ b/scripts/ugreen-power-led
@@ -1,0 +1,30 @@
+#!/usr/bin/bash
+
+# use variables from config file (unRAID specific)
+if [[ -f /boot/config/plugins/ugreenleds-driver/settings.cfg ]]; then
+    source /boot/config/plugins/ugreenleds-driver/settings.cfg
+fi
+
+# load environment variables
+if [[ -f /etc/ugreen-leds.conf ]]; then
+    source /etc/ugreen-leds.conf
+fi
+
+# Blink settings for the power LED
+# * none: no blinking
+# * breath <delay_on> <delay_off>: breathing blink
+# * blink <delay_on> <delay_off>: blinking
+BLINK_TYPE_POWER=${BLINK_TYPE_POWER:="none"}
+
+# brighness of the power LED
+BRIGHTNESS_POWER=${BRIGHTNESS_POWER:=255}
+
+# color of the power LED
+COLOR_POWER=${COLOR_POWER:="255 255 255"}
+
+# initialize LEDs
+if [[ -d /sys/class/leds/power ]]; then
+    echo "$BLINK_TYPE_POWER" > /sys/class/leds/power/blink_type
+    echo "$BRIGHTNESS_POWER" > /sys/class/leds/power/brightness
+    echo "$COLOR_POWER" > /sys/class/leds/power/color
+fi


### PR DESCRIPTION
It is quite simple, but I would like to have my power LED to be set alongside the net and disk LEDs on startup.

So I created the service in this patch and extended the configuration file.