### PR TITLE
Create option to dynamically calculate the color of the network LED

### DIFF
--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -108,6 +108,18 @@ COLOR_NETDEV_LINK_1000="0 0 255"
 COLOR_NETDEV_LINK_2500="255 255 0"
 COLOR_NETDEV_LINK_10000="255 255 255"
 
+# Monitor the link speed and calculate the color for the current link speed (default: false)
+CHECK_LINK_SPEED_DYNAMIC=false
+
+# The color to use for the lowest specified speed (default: 255 0 0)
+CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW="255 0 0"
+# The color to use for the highest specified speed (default: 0 255 0)
+CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH="0 255 0"
+# The speed at which the low color should be shown (default: 0)
+CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW=0
+# The speed at which the high color should be shown (default: 10000)
+CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH=10000
+
 # color of the netdev when unable to ping the gateway
 COLOR_NETDEV_GATEWAY_UNREACHABLE="255 0 0"
 

--- a/scripts/ugreen-netdevmon
+++ b/scripts/ugreen-netdevmon
@@ -56,7 +56,7 @@ function set_netdev_normal_color() {
     if [[ $CHECK_LINK_SPEED_DYNAMIC == true ]]; then
         # Get speed and percentage of set speeds
         speed=$(cat /sys/class/net/$netdev_name/speed)
-        percentage=$(bc -l <<< "$speed - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW) / ($CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW)")
+        percentage=$(bc -l <<< "($speed - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW) / ($CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW)")
 
         # Split colors
         IFS=' '

--- a/scripts/ugreen-netdevmon
+++ b/scripts/ugreen-netdevmon
@@ -60,13 +60,14 @@ function set_netdev_normal_color() {
 
         # Split colors
         IFS=' '
-        read -ra channels_low <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW
-        read -ra channels_high <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH
+        read -r red_low green_low blue_low <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW
+        read -r red_high green_high blue_high <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH
 
         # Calculate colors and create new string
-        red=$(bc -l <<< "scale=0; ${channels_low[0]} + $percentage * (${channels_high[0]} - ${channels_low[0]})")
-        green=$(bc -l <<< "scale=0; ${channels_low[1]} + $percentage * (${channels_high[1]} - ${channels_low[1]})")
-        blue=$(bc -l <<< "scale=0; ${channels_low[2]} + $percentage * (${channels_high[2]} - ${channels_low[2]})")
+        # Division by 1 is required because otherwise bc does not respect the scale parameter
+        red=$(bc -l <<< "scale=0; $red_low + $percentage * ($red_high - $red_low)/1")
+        green=$(bc -l <<< "scale=0; $green_low + $percentage * ($green_high - $green_low)/1")
+        blue=$(bc -l <<< "scale=0; $blue_low + $percentage * ($blue_high - $blue_low)/1")
         color="$red $green $blue"
     elif [[ $CHECK_LINK_SPEED == true ]]; then
         case $(cat /sys/class/net/$netdev_name/speed) in

--- a/scripts/ugreen-netdevmon
+++ b/scripts/ugreen-netdevmon
@@ -33,6 +33,12 @@ CHECK_NETDEV_INTERVAL=${CHECK_NETDEV_INTERVAL:=60}
 CHECK_GATEWAY_CONNECTIVITY=${CHECK_GATEWAY_CONNECTIVITY:=false} 
 CHECK_LINK_SPEED=${CHECK_LINK_SPEED:=false} 
 
+CHECK_LINK_SPEED_DYNAMIC=${CHECK_LINK_SPEED_DYNAMIC:=false}
+CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW=${CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW:="255 0 0"}
+CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH=${CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH:="0 255 0"}
+CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW=${CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW:=0}
+CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH=${CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH:=10000}
+
 led="netdev"
 netdev_name=$1
 echo netdev > /sys/class/leds/$led/trigger
@@ -47,7 +53,22 @@ echo $BRIGHTNESS_NETDEV_LED > /sys/class/leds/$led/brightness
 function set_netdev_normal_color() {
     color=$COLOR_NETDEV_NORMAL
 
-    if [[ $CHECK_LINK_SPEED == true ]]; then
+    if [[ $CHECK_LINK_SPEED_DYNAMIC == true ]]; then
+        # Get speed and percentage of set speeds
+        speed=$(cat /sys/class/net/$netdev_name/speed)
+        percentage=$(bc -l <<< "$speed - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW) / ($CHECK_LINK_SPEED_DYNAMIC_SPEED_HIGH - $CHECK_LINK_SPEED_DYNAMIC_SPEED_LOW)")
+
+        # Split colors
+        IFS=' '
+        read -ra channels_low <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_LOW
+        read -ra channels_high <<< $CHECK_LINK_SPEED_DYNAMIC_COLOR_HIGH
+
+        # Calculate colors and create new string
+        red=$(bc -l <<< "scale=0; ${channels_low[0]} + $percentage * (${channels_high[0]} - ${channels_low[0]})")
+        green=$(bc -l <<< "scale=0; ${channels_low[1]} + $percentage * (${channels_high[1]} - ${channels_low[1]})")
+        blue=$(bc -l <<< "scale=0; ${channels_low[2]} + $percentage * (${channels_high[2]} - ${channels_low[2]})")
+        color="$red $green $blue"
+    elif [[ $CHECK_LINK_SPEED == true ]]; then
         case $(cat /sys/class/net/$netdev_name/speed) in
             100)   color=${COLOR_NETDEV_LINK_100:=$COLOR_NETDEV_NORMAL};;
             1000)  color=${COLOR_NETDEV_LINK_1000:=$COLOR_NETDEV_NORMAL};;


### PR DESCRIPTION
This adds in the possibility to have the tool itself dynamically calculate the color shown by the network LED depending on the current link speed.

This was created as the tool currently only allows fixed speeds at 100M, 1G, 2.5G and 10G. If one for example uses bonding, these speeds may not apply, so I coded a small solution which sets a low and high speed, specifies the colors for it and then the program calculates the colors for any speed in between.

(Squash commits if possible)