### PR TITLE
fix: name of config file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To see how to map the disk LEDs to correct disk slots, please read the [Disk Map
 
 #### Start at Boot (for Debian 12)
 
-The configure file of `ugreen-diskiomon` and `ugreen-netdevmon` is `/etc/ugreen-led.conf`.  
+The configure file of `ugreen-diskiomon` and `ugreen-netdevmon` is `/etc/ugreen-leds.conf`.  
 Please see `scripts/ugreen-leds.conf` for an example.
 
 - Add the following lines to `/etc/modules-load.d/ugreen-led.conf`


### PR DESCRIPTION
In one line of the readme the config file is referred to as `/etc/ugreen-led.conf` when it should be `/etc/ugreen-leds.conf`instead.