### PR TITLE
Introduce userspace and eBPF LED controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.o
 dx4600_leds_cli
 ugreen_leds_cli
+ugreen-ledd
+ugreen-ledd-test
+ugreen-bpf-load-test
+ebpf/build/
 run.sh
 zpool_leds.sh
 

--- a/ebpf/Makefile
+++ b/ebpf/Makefile
@@ -1,0 +1,80 @@
+CLANG ?= clang
+LLVM_LINK ?= llvm-link
+LLC ?= llc
+CC ?= gcc
+PKG_CONFIG ?= pkg-config
+
+MULTIARCH ?= $(shell $(CC) -dumpmachine)
+ARCH ?= x86
+
+INCLUDE_DIR := include
+SOURCE_DIR := src
+TEST_DIR := tests
+BUILD_DIR := build
+
+BPF_SOURCES := bpf/maps.bpf.c bpf/network.bpf.c bpf/disk.bpf.c
+BPF_BITCODE := $(patsubst bpf/%.c,$(BUILD_DIR)/bpf/%.bc,$(BPF_SOURCES))
+BPF_CFLAGS := -O2 -g -target bpf -D__TARGET_ARCH_$(ARCH) \
+              -I/usr/include/$(MULTIARCH) -I$(INCLUDE_DIR) -Ibpf
+
+USER_SOURCES := $(SOURCE_DIR)/main.c $(SOURCE_DIR)/config.c \
+                $(SOURCE_DIR)/scheduler.c $(SOURCE_DIR)/led_controller.c \
+                $(SOURCE_DIR)/network_led.c $(SOURCE_DIR)/disk_led.c \
+                $(SOURCE_DIR)/disk_layout.c \
+                $(SOURCE_DIR)/power_led.c $(SOURCE_DIR)/bpf_runtime.c
+USER_OBJECTS := $(patsubst $(SOURCE_DIR)/%.c,$(BUILD_DIR)/src/%.o,$(USER_SOURCES))
+USER_CFLAGS := -std=gnu11 -O2 -g -Wall -Wextra -Wpedantic \
+               -I$(INCLUDE_DIR) -I$(SOURCE_DIR) \
+               $(shell $(PKG_CONFIG) --cflags libbpf)
+USER_LIBS := $(shell $(PKG_CONFIG) --libs libbpf)
+
+TEST_OBJECTS := $(BUILD_DIR)/tests/ugreen_ledd_test.o \
+                $(BUILD_DIR)/tests/config.o $(BUILD_DIR)/tests/scheduler.o \
+                $(BUILD_DIR)/tests/disk_layout.o
+
+.PHONY: all test clean
+
+all: ugreen_led.bpf.o ugreen-ledd
+
+$(BUILD_DIR)/bpf $(BUILD_DIR)/src $(BUILD_DIR)/tests:
+	mkdir -p $@
+
+$(BUILD_DIR)/bpf/%.bpf.bc: bpf/%.bpf.c bpf/maps.bpf.h $(INCLUDE_DIR)/ugreen_bpf_shared.h | $(BUILD_DIR)/bpf
+	$(CLANG) $(BPF_CFLAGS) -emit-llvm -c $< -o $@
+
+ugreen_led.bpf.o: $(BPF_BITCODE)
+	$(LLVM_LINK) $^ -o $(BUILD_DIR)/bpf/ugreen_led.bc
+	$(LLC) -march=bpf -filetype=obj $(BUILD_DIR)/bpf/ugreen_led.bc -o $@
+
+$(BUILD_DIR)/src/%.o: $(SOURCE_DIR)/%.c | $(BUILD_DIR)/src
+	$(CC) $(USER_CFLAGS) -MMD -MP -c $< -o $@
+
+ugreen-ledd: $(USER_OBJECTS)
+	$(CC) $^ -o $@ $(USER_LIBS)
+
+$(BUILD_DIR)/tests/ugreen_ledd_test.o: $(TEST_DIR)/ugreen_ledd_test.c | $(BUILD_DIR)/tests
+	$(CC) $(USER_CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/tests/config.o: $(SOURCE_DIR)/config.c | $(BUILD_DIR)/tests
+	$(CC) $(USER_CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/tests/scheduler.o: $(SOURCE_DIR)/scheduler.c | $(BUILD_DIR)/tests
+	$(CC) $(USER_CFLAGS) -c $< -o $@
+
+$(BUILD_DIR)/tests/disk_layout.o: $(SOURCE_DIR)/disk_layout.c | $(BUILD_DIR)/tests
+	$(CC) $(USER_CFLAGS) -c $< -o $@
+
+ugreen-ledd-test: $(TEST_OBJECTS)
+	$(CC) $^ -o $@
+
+test: ugreen-ledd-test
+	./ugreen-ledd-test
+
+ugreen-bpf-load-test: $(TEST_DIR)/bpf_load_test.c
+	$(CC) $(USER_CFLAGS) $< -o $@ $(USER_LIBS)
+
+clean:
+	rm -rf $(BUILD_DIR) ugreen_led.bpf.o ugreen-ledd ugreen-ledd-test \
+		ugreen-bpf-load-test
+
+-include $(USER_OBJECTS:.o=.d)

--- a/ebpf/README.md
+++ b/ebpf/README.md
@@ -1,0 +1,158 @@
+# Event-driven UGREEN LED daemon
+
+This backend controls the power, network, and disk LEDs through one userspace
+daemon and one direct I2C connection to the UGREEN LED MCU. It does not require
+the `led-ugreen` DKMS module.
+
+## Architecture
+
+The sources are deliberately separated by responsibility:
+
+```text
+bpf/       eBPF maps, TC network collectors, and block-I/O collector
+include/   event ABI shared by eBPF and userspace
+src/       configuration, I2C, discovery, policy, and event-loop modules
+tests/     userspace regression tests
+systemd/   example per-interface service unit
+```
+
+The three BPF translation units are linked into `ugreen_led.bpf.o`:
+
+- TC ingress and egress programs aggregate network RX/TX bytes.
+- `block:block_rq_issue` observes requests sent to configured physical disks.
+- Both collectors rate-limit events in-kernel and publish them through one
+  ring buffer. Idle devices cause no userspace wakeups.
+
+`ugreen-ledd` is the sole MCU owner. It serializes commands and performs the
+MCU acknowledgement/retry sequence before caching state.
+
+## LED behavior
+
+### Power
+
+At startup the daemon applies `COLOR_POWER`, `BRIGHTNESS_POWER`, and
+`BLINK_TYPE_POWER`. Blink and breath effects run in the MCU without periodic
+userspace work.
+
+### Network
+
+Network behavior preserves the tested standalone daemon defaults:
+
+- interval: 100 ms
+- pulse: 45 ms
+- RX: `0,96,255`
+- TX: `255,0,0`
+
+Mixed traffic is scheduled according to the current coalesced RX/TX byte ratio
+without allowing old traffic to pin the color.
+
+### Disks
+
+The daemon discovers physical SATA disks through sysfs and supports the
+existing `ata`, `hctl`, and `serial` mapping modes. Known model layouts include
+the reordered six-bay DXP6800 mapping. Serial mapping reads
+`ID_SERIAL_SHORT` from the udev database.
+
+Both `COLOR_DISK_HEALTH` and the existing
+`COLOR_DISK_HEALTH_PER_DISK[diskN]` overrides are honored.
+
+The BPF program filters requests to mapped physical devices, so logical RAID,
+device-mapper, and filesystem activity is represented by the bays that
+actually receive I/O. At the first event in a burst the MCU starts hardware
+blinking for that disk. Further events extend an idle deadline; after the
+deadline the LED returns to its steady state. This avoids issuing two I2C
+commands for every pulse when several RAID members are busy.
+
+Disk presence is updated from block-device uevents. Empty slots are turned
+off. `LED_INVERT=1` keeps healthy disks steadily lit and makes activity the dark
+part of the blink cycle; `LED_INVERT=0` uses light-on-activity behavior.
+
+SMART, ZFS health, and ATA standby policies are not yet part of this backend.
+They remain separate from activity collection because they require slow
+userspace queries rather than eBPF hooks.
+
+## Dependencies
+
+On Debian:
+
+```sh
+sudo apt install build-essential clang llvm libbpf-dev libelf-dev zlib1g-dev \
+    pkg-config i2c-tools
+sudo modprobe i2c-dev
+```
+
+The kernel must provide BPF ring buffers, TC BPF, and the
+`block:block_rq_issue` tracepoint.
+
+## Build and test
+
+```sh
+cd ebpf
+make
+make test
+make ugreen-bpf-load-test
+sudo ./ugreen-bpf-load-test
+```
+
+The build produces:
+
+```text
+ugreen_led.bpf.o
+ugreen-ledd
+```
+
+## Configuration
+
+The daemon safely parses the relevant scalar settings from
+`/etc/ugreen-leds.conf`; it does not source the file as a shell script.
+
+Important settings and defaults are:
+
+```sh
+NETDEV_INTERFACE=""
+NETDEV_EBPF_INTERVAL_MS=100
+NETDEV_EBPF_PULSE_MS=45
+COLOR_NETDEV_RX="0 96 255"
+COLOR_NETDEV_TX="255 0 0"
+BRIGHTNESS_NETDEV_LED="255"
+
+MAPPING_METHOD=ata
+DISK_SERIAL="SN1 SN2 SN3 SN4"
+DISK_EBPF_INTERVAL_MS=100
+DISK_EBPF_HOLD_MS=200
+DISK_EBPF_PULSE_MS=45
+LED_INVERT=0
+COLOR_DISK_HEALTH="255 255 255"
+BRIGHTNESS_DISK_LEDS="255"
+
+BLINK_TYPE_POWER="none"
+BRIGHTNESS_POWER=255
+COLOR_POWER="255 255 255"
+```
+
+`BLINK_TYPE_POWER` also accepts `blink ON_MS OFF_MS` and
+`breath ON_MS OFF_MS`.
+
+Command-line options override the configuration file. For example:
+
+```sh
+sudo ./ugreen-ledd -i "$IF" -v
+sudo ./ugreen-ledd --no-power --no-disks -i "$IF"
+sudo ./ugreen-ledd --no-network
+```
+
+## Direct-I2C ownership
+
+The DKMS module and the direct-I2C daemon cannot own the MCU simultaneously.
+Before testing, stop the old policy services and unload the module:
+
+```sh
+sudo systemctl stop 'ugreen-netdevmon@*.service' 2>/dev/null || true
+sudo systemctl stop ugreen-diskiomon.service ugreen-power-led.service \
+    2>/dev/null || true
+sudo modprobe -r led_ugreen
+sudo modprobe i2c-dev
+```
+
+The daemon detaches only the TC filters it installed and deliberately leaves
+an existing `clsact` qdisc in place.

--- a/ebpf/bpf/disk.bpf.c
+++ b/ebpf/bpf/disk.bpf.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/bpf.h>
+#include <stdbool.h>
+#include <bpf/bpf_helpers.h>
+
+#include "maps.bpf.h"
+
+#define DEFAULT_INTERVAL_NS (100ULL * 1000ULL * 1000ULL)
+
+/* Common tracepoint fields occupy the first eight bytes. */
+struct block_rq_issue_context {
+    __u64 common;
+    __u32 dev;
+};
+
+SEC("tracepoint/block/block_rq_issue")
+int ugreen_disk_issue(struct block_rq_issue_context *ctx)
+{
+    const __u32 config_key = 0;
+    const struct ugreen_bpf_config *config;
+    const __u32 *led_id;
+    struct disk_state *state;
+    struct ugreen_led_event event = {};
+    __u32 dev = ctx->dev;
+    __u64 interval = DEFAULT_INTERVAL_NS;
+    __u64 now;
+    __u64 old_deadline;
+
+    led_id = bpf_map_lookup_elem(&disk_targets, &dev);
+    if (!led_id)
+        return 0;
+
+    state = bpf_map_lookup_elem(&disk_states, &dev);
+    if (!state)
+        return 0;
+
+    config = bpf_map_lookup_elem(&config_map, &config_key);
+    if (config && config->disk_interval_ns)
+        interval = config->disk_interval_ns;
+
+    now = bpf_ktime_get_ns();
+    old_deadline = state->next_emit_ns;
+    if ((!old_deadline || now >= old_deadline) &&
+        __sync_val_compare_and_swap(&state->next_emit_ns, old_deadline,
+                                    now + interval) == old_deadline) {
+        event.timestamp_ns = now;
+        event.source = dev;
+        event.kind = UGREEN_EVENT_DISK;
+        event.led_id = (__u8)*led_id;
+        bpf_ringbuf_output(&events, &event, sizeof(event), 0);
+    }
+
+    return 0;
+}

--- a/ebpf/bpf/maps.bpf.c
+++ b/ebpf/bpf/maps.bpf.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "maps.bpf.h"
+
+struct config_map_definition config_map SEC(".maps");
+struct network_state_map_definition network_state_map SEC(".maps");
+struct disk_targets_map_definition disk_targets SEC(".maps");
+struct disk_states_map_definition disk_states SEC(".maps");
+struct events_map_definition events SEC(".maps");
+
+char LICENSE[] SEC("license") = "GPL";

--- a/ebpf/bpf/maps.bpf.h
+++ b/ebpf/bpf/maps.bpf.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_MAPS_BPF_H
+#define UGREEN_MAPS_BPF_H
+
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+
+#include "ugreen_bpf_shared.h"
+
+struct network_state {
+    struct bpf_spin_lock lock;
+    __u32 pad;
+    __u64 rx_bytes;
+    __u64 tx_bytes;
+    __u64 next_emit_ns;
+};
+
+struct disk_state {
+    __u64 next_emit_ns;
+};
+
+struct config_map_definition {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct ugreen_bpf_config);
+};
+
+struct network_state_map_definition {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct network_state);
+};
+
+struct disk_targets_map_definition {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 8);
+    __type(key, __u32);
+    __type(value, __u32);
+};
+
+struct disk_states_map_definition {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 8);
+    __type(key, __u32);
+    __type(value, struct disk_state);
+};
+
+struct events_map_definition {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024);
+};
+
+extern struct config_map_definition config_map;
+extern struct network_state_map_definition network_state_map;
+extern struct disk_targets_map_definition disk_targets;
+extern struct disk_states_map_definition disk_states;
+extern struct events_map_definition events;
+
+#endif

--- a/ebpf/bpf/network.bpf.c
+++ b/ebpf/bpf/network.bpf.c
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <stdbool.h>
+#include <bpf/bpf_helpers.h>
+
+#include "maps.bpf.h"
+
+#define DEFAULT_INTERVAL_NS (100ULL * 1000ULL * 1000ULL)
+
+static __always_inline int account_packet(struct __sk_buff *skb, bool is_rx)
+{
+    const __u32 key = 0;
+    const struct ugreen_bpf_config *config;
+    struct network_state *state;
+    struct ugreen_led_event event = {};
+    __u64 interval = DEFAULT_INTERVAL_NS;
+    __u64 now;
+    bool emit = false;
+
+    state = bpf_map_lookup_elem(&network_state_map, &key);
+    if (!state)
+        return TC_ACT_OK;
+
+    config = bpf_map_lookup_elem(&config_map, &key);
+    if (config && config->network_interval_ns)
+        interval = config->network_interval_ns;
+
+    now = bpf_ktime_get_ns();
+    bpf_spin_lock(&state->lock);
+
+    if (is_rx)
+        state->rx_bytes += skb->len;
+    else
+        state->tx_bytes += skb->len;
+
+    if (!state->next_emit_ns || now >= state->next_emit_ns) {
+        event.timestamp_ns = now;
+        event.first_bytes = state->rx_bytes;
+        event.second_bytes = state->tx_bytes;
+        event.source = skb->ifindex;
+        event.kind = UGREEN_EVENT_NETWORK;
+
+        state->rx_bytes = 0;
+        state->tx_bytes = 0;
+        state->next_emit_ns = now + interval;
+        emit = true;
+    }
+
+    bpf_spin_unlock(&state->lock);
+    if (emit)
+        bpf_ringbuf_output(&events, &event, sizeof(event), 0);
+
+    return TC_ACT_OK;
+}
+
+SEC("tc")
+int ugreen_network_ingress(struct __sk_buff *skb)
+{
+    return account_packet(skb, true);
+}
+
+SEC("tc")
+int ugreen_network_egress(struct __sk_buff *skb)
+{
+    return account_packet(skb, false);
+}

--- a/ebpf/include/ugreen_bpf_shared.h
+++ b/ebpf/include/ugreen_bpf_shared.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_BPF_SHARED_H
+#define UGREEN_BPF_SHARED_H
+
+#include <linux/types.h>
+
+enum ugreen_event_kind {
+    UGREEN_EVENT_NETWORK = 1,
+    UGREEN_EVENT_DISK = 2,
+};
+
+struct ugreen_bpf_config {
+    __u64 network_interval_ns;
+    __u64 disk_interval_ns;
+};
+
+struct ugreen_led_event {
+    __u64 timestamp_ns;
+    __u64 first_bytes;
+    __u64 second_bytes;
+    __u32 source;
+    __u16 kind;
+    __u8 led_id;
+    __u8 reserved;
+};
+
+#endif

--- a/ebpf/src/bpf_runtime.c
+++ b/ebpf/src/bpf_runtime.c
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "bpf_runtime.h"
+
+#include <bpf/bpf.h>
+#include <errno.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ugreen_bpf_shared.h"
+
+static int set_autoload(struct bpf_object *object, const char *name,
+                        bool enabled)
+{
+    struct bpf_program *program = bpf_object__find_program_by_name(object, name);
+
+    if (!program)
+        return -ENOENT;
+    return bpf_program__set_autoload(program, enabled);
+}
+
+static int attach_tc(struct bpf_runtime *runtime)
+{
+    struct bpf_program *ingress =
+        bpf_object__find_program_by_name(runtime->object,
+                                         "ugreen_network_ingress");
+    struct bpf_program *egress =
+        bpf_object__find_program_by_name(runtime->object,
+                                         "ugreen_network_egress");
+    struct bpf_tc_hook qdisc = {
+        .sz = sizeof(qdisc),
+        .ifindex = runtime->ifindex,
+        .attach_point = BPF_TC_INGRESS | BPF_TC_EGRESS,
+    };
+    struct bpf_tc_hook ingress_hook = {
+        .sz = sizeof(ingress_hook),
+        .ifindex = runtime->ifindex,
+        .attach_point = BPF_TC_INGRESS,
+    };
+    struct bpf_tc_hook egress_hook = {
+        .sz = sizeof(egress_hook),
+        .ifindex = runtime->ifindex,
+        .attach_point = BPF_TC_EGRESS,
+    };
+    struct bpf_tc_opts ingress_options = {
+        .sz = sizeof(ingress_options),
+        .handle = 1,
+        .priority = UGREEN_TC_PRIORITY,
+    };
+    struct bpf_tc_opts egress_options = {
+        .sz = sizeof(egress_options),
+        .handle = 2,
+        .priority = UGREEN_TC_PRIORITY,
+    };
+    int error;
+
+    if (!ingress || !egress)
+        return -ENOENT;
+    error = bpf_tc_hook_create(&qdisc);
+    if (error && error != -EEXIST)
+        return error;
+
+    ingress_options.prog_fd = bpf_program__fd(ingress);
+    error = bpf_tc_attach(&ingress_hook, &ingress_options);
+    if (error)
+        return error;
+    runtime->ingress_attached = true;
+
+    egress_options.prog_fd = bpf_program__fd(egress);
+    error = bpf_tc_attach(&egress_hook, &egress_options);
+    if (error)
+        return error;
+    runtime->egress_attached = true;
+    return 0;
+}
+
+static void detach_tc(struct bpf_runtime *runtime)
+{
+    struct bpf_tc_hook hook = {
+        .sz = sizeof(hook),
+        .ifindex = runtime->ifindex,
+    };
+    struct bpf_tc_opts options = {
+        .sz = sizeof(options),
+        .priority = UGREEN_TC_PRIORITY,
+    };
+
+    if (runtime->ingress_attached) {
+        hook.attach_point = BPF_TC_INGRESS;
+        options.handle = 1;
+        (void)bpf_tc_detach(&hook, &options);
+        runtime->ingress_attached = false;
+    }
+    if (runtime->egress_attached) {
+        hook.attach_point = BPF_TC_EGRESS;
+        options.handle = 2;
+        (void)bpf_tc_detach(&hook, &options);
+        runtime->egress_attached = false;
+    }
+}
+
+int bpf_runtime_start(struct bpf_runtime *runtime,
+                      const struct config *config,
+                      ring_buffer_sample_fn callback, void *callback_context)
+{
+    struct ugreen_bpf_config bpf_config = {
+        .network_interval_ns =
+            (uint64_t)config->network_interval_ms * 1000000ULL,
+        .disk_interval_ns =
+            (uint64_t)config->disk_interval_ms * 1000000ULL,
+    };
+    struct bpf_program *disk_program;
+    struct bpf_map *map;
+    uint32_t key = 0;
+    int error;
+
+    memset(runtime, 0, sizeof(*runtime));
+    runtime->object = bpf_object__open_file(config->bpf_object, NULL);
+    if (!runtime->object)
+        return -(errno ? errno : EIO);
+
+    error = set_autoload(runtime->object, "ugreen_network_ingress",
+                         config->network_enabled);
+    if (!error)
+        error = set_autoload(runtime->object, "ugreen_network_egress",
+                             config->network_enabled);
+    if (!error)
+        error = set_autoload(runtime->object, "ugreen_disk_issue",
+                             config->disks_enabled);
+    if (error < 0)
+        goto fail;
+
+    error = bpf_object__load(runtime->object);
+    if (error < 0)
+        goto fail;
+
+    map = bpf_object__find_map_by_name(runtime->object, "config_map");
+    if (!map) {
+        error = -ENOENT;
+        goto fail;
+    }
+    if (bpf_map_update_elem(bpf_map__fd(map), &key, &bpf_config, BPF_ANY) < 0) {
+        error = -errno;
+        goto fail;
+    }
+
+    if (config->network_enabled) {
+        runtime->ifindex = (int)if_nametoindex(config->interface);
+        if (!runtime->ifindex) {
+            error = -ENODEV;
+            goto fail;
+        }
+        error = attach_tc(runtime);
+        if (error < 0)
+            goto fail;
+    }
+
+    if (config->disks_enabled) {
+        disk_program = bpf_object__find_program_by_name(runtime->object,
+                                                        "ugreen_disk_issue");
+        if (!disk_program) {
+            error = -ENOENT;
+            goto fail;
+        }
+        runtime->disk_link = bpf_program__attach_tracepoint(
+            disk_program, "block", "block_rq_issue");
+        error = libbpf_get_error(runtime->disk_link);
+        if (error) {
+            runtime->disk_link = NULL;
+            goto fail;
+        }
+    }
+
+    map = bpf_object__find_map_by_name(runtime->object, "events");
+    if (!map) {
+        error = -ENOENT;
+        goto fail;
+    }
+    runtime->ring = ring_buffer__new(bpf_map__fd(map), callback,
+                                     callback_context, NULL);
+    if (!runtime->ring) {
+        error = -(errno ? errno : EIO);
+        goto fail;
+    }
+    return 0;
+
+fail:
+    bpf_runtime_stop(runtime);
+    return error;
+}
+
+void bpf_runtime_stop(struct bpf_runtime *runtime)
+{
+    detach_tc(runtime);
+    if (runtime->disk_link)
+        bpf_link__destroy(runtime->disk_link);
+    if (runtime->ring)
+        ring_buffer__free(runtime->ring);
+    if (runtime->object)
+        bpf_object__close(runtime->object);
+    memset(runtime, 0, sizeof(*runtime));
+}
+
+int bpf_runtime_epoll_fd(const struct bpf_runtime *runtime)
+{
+    return runtime->ring ? ring_buffer__epoll_fd(runtime->ring) : -ENOENT;
+}
+
+int bpf_runtime_consume(struct bpf_runtime *runtime)
+{
+    return runtime->ring ? ring_buffer__consume(runtime->ring) : -ENOENT;
+}
+
+static int clear_map(struct bpf_map *map)
+{
+    uint32_t key;
+    int fd;
+
+    if (!map)
+        return -ENOENT;
+    fd = bpf_map__fd(map);
+    while (bpf_map_get_next_key(fd, NULL, &key) == 0) {
+        if (bpf_map_delete_elem(fd, &key) < 0 && errno != ENOENT)
+            return -errno;
+    }
+    return 0;
+}
+
+int bpf_runtime_clear_disk_targets(struct bpf_runtime *runtime)
+{
+    int error = clear_map(bpf_object__find_map_by_name(runtime->object,
+                                                        "disk_targets"));
+    if (error < 0)
+        return error;
+    return clear_map(bpf_object__find_map_by_name(runtime->object,
+                                                   "disk_states"));
+}
+
+int bpf_runtime_set_disk_target(struct bpf_runtime *runtime,
+                                uint32_t dev, uint8_t led_id)
+{
+    struct disk_state_value {
+        uint64_t next_emit_ns;
+    } state = {0};
+    struct bpf_map *targets = bpf_object__find_map_by_name(runtime->object,
+                                                           "disk_targets");
+    struct bpf_map *states = bpf_object__find_map_by_name(runtime->object,
+                                                          "disk_states");
+    uint32_t value = led_id;
+
+    if (!targets || !states)
+        return -ENOENT;
+    if (bpf_map_update_elem(bpf_map__fd(states), &dev, &state, BPF_ANY) < 0)
+        return -errno;
+    if (bpf_map_update_elem(bpf_map__fd(targets), &dev, &value, BPF_ANY) < 0) {
+        int error = -errno;
+        (void)bpf_map_delete_elem(bpf_map__fd(states), &dev);
+        return error;
+    }
+    return 0;
+}

--- a/ebpf/src/bpf_runtime.h
+++ b/ebpf/src/bpf_runtime.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_BPF_RUNTIME_H
+#define UGREEN_BPF_RUNTIME_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <bpf/libbpf.h>
+
+#include "config.h"
+
+#define UGREEN_TC_PRIORITY 49152U
+
+struct bpf_runtime {
+    struct bpf_object *object;
+    struct bpf_link *disk_link;
+    struct ring_buffer *ring;
+    int ifindex;
+    bool ingress_attached;
+    bool egress_attached;
+};
+
+int bpf_runtime_start(struct bpf_runtime *runtime,
+                      const struct config *config,
+                      ring_buffer_sample_fn callback, void *callback_context);
+void bpf_runtime_stop(struct bpf_runtime *runtime);
+int bpf_runtime_epoll_fd(const struct bpf_runtime *runtime);
+int bpf_runtime_consume(struct bpf_runtime *runtime);
+int bpf_runtime_clear_disk_targets(struct bpf_runtime *runtime);
+int bpf_runtime_set_disk_target(struct bpf_runtime *runtime,
+                                uint32_t dev, uint8_t led_id);
+
+#endif

--- a/ebpf/src/config.c
+++ b/ebpf/src/config.c
@@ -1,0 +1,465 @@
+// SPDX-License-Identifier: GPL-2.0
+#define _GNU_SOURCE
+
+#include "config.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int parse_unsigned(const char *text, unsigned minimum,
+                          unsigned maximum, unsigned *output)
+{
+    char *end = NULL;
+    unsigned long value;
+
+    errno = 0;
+    value = strtoul(text, &end, 10);
+    if (errno || end == text || *end || value < minimum || value > maximum)
+        return -EINVAL;
+    *output = (unsigned)value;
+    return 0;
+}
+
+static int parse_boolean(const char *text, bool *output)
+{
+    if (!strcasecmp(text, "true") || !strcmp(text, "1") ||
+        !strcasecmp(text, "yes")) {
+        *output = true;
+        return 0;
+    }
+    if (!strcasecmp(text, "false") || !strcmp(text, "0") ||
+        !strcasecmp(text, "no")) {
+        *output = false;
+        return 0;
+    }
+    return -EINVAL;
+}
+
+static int parse_rgb(const char *text, struct rgb *output)
+{
+    unsigned r, g, b;
+    char tail;
+
+    if (sscanf(text, "%u,%u,%u%c", &r, &g, &b, &tail) != 3 &&
+        sscanf(text, "%u %u %u%c", &r, &g, &b, &tail) != 3)
+        return -EINVAL;
+    if (r > 255 || g > 255 || b > 255)
+        return -ERANGE;
+    output->r = (uint8_t)r;
+    output->g = (uint8_t)g;
+    output->b = (uint8_t)b;
+    return 0;
+}
+
+static char *trim(char *text)
+{
+    char *end;
+
+    while (isspace((unsigned char)*text))
+        ++text;
+    end = text + strlen(text);
+    while (end > text && isspace((unsigned char)end[-1]))
+        --end;
+    *end = '\0';
+    return text;
+}
+
+static char *config_value(char *text)
+{
+    char quote = '\0';
+    char *cursor;
+    size_t length;
+
+    for (cursor = text; *cursor; ++cursor) {
+        if ((*cursor == '\'' || *cursor == '"') &&
+            (!quote || quote == *cursor))
+            quote = quote ? '\0' : *cursor;
+        else if (*cursor == '#' && !quote) {
+            *cursor = '\0';
+            break;
+        }
+    }
+
+    text = trim(text);
+    length = strlen(text);
+    if (length >= 2 && ((text[0] == '"' && text[length - 1] == '"') ||
+                        (text[0] == '\'' && text[length - 1] == '\''))) {
+        text[length - 1] = '\0';
+        ++text;
+    }
+    return text;
+}
+
+static int parse_mapping(const char *text, enum disk_mapping_method *output)
+{
+    if (!strcmp(text, "ata"))
+        *output = DISK_MAPPING_ATA;
+    else if (!strcmp(text, "hctl"))
+        *output = DISK_MAPPING_HCTL;
+    else if (!strcmp(text, "serial"))
+        *output = DISK_MAPPING_SERIAL;
+    else
+        return -EINVAL;
+    return 0;
+}
+
+static int copy_interface(const char *text, struct config *config)
+{
+    size_t length = strlen(text);
+
+    if (!length || length >= sizeof(config->interface))
+        return -EINVAL;
+    memcpy(config->interface, text, length + 1);
+    config->network_enabled = true;
+    return 0;
+}
+
+static int parse_serials(const char *text, struct config *config)
+{
+    char *copy = strdup(text);
+    char *save = NULL;
+    char *token;
+    unsigned slot = 0;
+
+    if (!copy)
+        return -ENOMEM;
+    memset(config->disk_serials, 0, sizeof(config->disk_serials));
+    for (token = strtok_r(copy, " \t,", &save); token;
+         token = strtok_r(NULL, " \t,", &save)) {
+        if (slot >= UGREEN_DISK_COUNT ||
+            strlen(token) >= sizeof(config->disk_serials[slot])) {
+            free(copy);
+            return -E2BIG;
+        }
+        snprintf(config->disk_serials[slot],
+                 sizeof(config->disk_serials[slot]), "%s", token);
+        ++slot;
+    }
+    free(copy);
+    return 0;
+}
+
+static int parse_power_mode(const char *text, struct config *config)
+{
+    char mode[16];
+    unsigned on_ms = 0;
+    unsigned off_ms = 0;
+    char tail;
+    int fields = sscanf(text, "%15s %u %u %c", mode, &on_ms, &off_ms, &tail);
+
+    if (fields == 1 && !strcmp(mode, "none")) {
+        config->power_mode = POWER_MODE_ON;
+        return 0;
+    }
+    if (fields != 3 || on_ms > UINT16_MAX || off_ms > UINT16_MAX ||
+        on_ms + off_ms > UINT16_MAX)
+        return -EINVAL;
+    if (!strcmp(mode, "blink"))
+        config->power_mode = POWER_MODE_BLINK;
+    else if (!strcmp(mode, "breath"))
+        config->power_mode = POWER_MODE_BREATH;
+    else
+        return -EINVAL;
+    config->power_on_ms = on_ms;
+    config->power_off_ms = off_ms;
+    return 0;
+}
+
+static int per_disk_color_slot(const char *key)
+{
+    unsigned disk;
+    char tail;
+
+    if (sscanf(key, "COLOR_DISK_HEALTH_PER_DISK[disk%u]%c",
+               &disk, &tail) != 1 || disk < 1 || disk > UGREEN_DISK_COUNT)
+        return -1;
+    return (int)disk - 1;
+}
+
+void config_set_defaults(struct config *config)
+{
+    memset(config, 0, sizeof(*config));
+    config->bpf_object = UGREEN_DEFAULT_BPF_OBJECT;
+    config->config_path = UGREEN_DEFAULT_CONFIG_PATH;
+    config->disks_enabled = true;
+    config->power_enabled = true;
+
+    config->network_interval_ms = 100;
+    config->network_pulse_ms = 45;
+    config->network_brightness = 255;
+    config->network_rx_color = (struct rgb){0, 96, 255};
+    config->network_tx_color = (struct rgb){255, 0, 0};
+
+    config->disk_interval_ms = 100;
+    config->disk_hold_ms = 200;
+    config->disk_pulse_ms = 45;
+    config->disk_brightness = 255;
+    config->disk_color = (struct rgb){255, 255, 255};
+    config->disk_invert = false;
+    config->disk_mapping = DISK_MAPPING_ATA;
+
+    config->power_brightness = 255;
+    config->power_color = (struct rgb){255, 255, 255};
+    config->power_mode = POWER_MODE_ON;
+}
+
+int config_load_file(const char *path, struct config *config)
+{
+    char *line = NULL;
+    size_t capacity = 0;
+    unsigned line_number = 0;
+    FILE *file = fopen(path, "re");
+    int result = 0;
+
+    if (!file)
+        return -errno;
+
+    while (getline(&line, &capacity, file) >= 0) {
+        char *key;
+        char *value;
+        char *equals;
+        int color_slot;
+        int error = 0;
+
+        ++line_number;
+        key = trim(line);
+        if (!*key || *key == '#' || !strncmp(key, "declare ", 8))
+            continue;
+        equals = strchr(key, '=');
+        if (!equals)
+            continue;
+        *equals = '\0';
+        value = config_value(equals + 1);
+        key = trim(key);
+
+        if (!strcmp(key, "NETDEV_INTERFACE")) {
+            if (!*value) {
+                config->interface[0] = '\0';
+                config->network_enabled = false;
+            } else {
+                error = copy_interface(value, config);
+            }
+        }
+        else if (!strcmp(key, "NETDEV_EBPF_INTERVAL_MS"))
+            error = parse_unsigned(value, 1, 1000,
+                                   &config->network_interval_ms);
+        else if (!strcmp(key, "NETDEV_EBPF_PULSE_MS"))
+            error = parse_unsigned(value, 0, 1000,
+                                   &config->network_pulse_ms);
+        else if (!strcmp(key, "COLOR_NETDEV_RX"))
+            error = parse_rgb(value, &config->network_rx_color);
+        else if (!strcmp(key, "COLOR_NETDEV_TX"))
+            error = parse_rgb(value, &config->network_tx_color);
+        else if (!strcmp(key, "BRIGHTNESS_NETDEV_LED"))
+            error = parse_unsigned(value, 0, 255,
+                                   &config->network_brightness);
+        else if (!strcmp(key, "DISK_EBPF_INTERVAL_MS"))
+            error = parse_unsigned(value, 1, 1000,
+                                   &config->disk_interval_ms);
+        else if (!strcmp(key, "DISK_EBPF_HOLD_MS"))
+            error = parse_unsigned(value, 1, 10000,
+                                   &config->disk_hold_ms);
+        else if (!strcmp(key, "DISK_EBPF_PULSE_MS"))
+            error = parse_unsigned(value, 1, 1000,
+                                   &config->disk_pulse_ms);
+        else if (!strcmp(key, "BRIGHTNESS_DISK_LEDS"))
+            error = parse_unsigned(value, 0, 255,
+                                   &config->disk_brightness);
+        else if (!strcmp(key, "COLOR_DISK_HEALTH"))
+            error = parse_rgb(value, &config->disk_color);
+        else if ((color_slot = per_disk_color_slot(key)) >= 0) {
+            error = parse_rgb(value, &config->disk_colors[color_slot]);
+            if (!error)
+                config->disk_color_set[color_slot] = true;
+        }
+        else if (!strcmp(key, "LED_INVERT"))
+            error = parse_boolean(value, &config->disk_invert);
+        else if (!strcmp(key, "MAPPING_METHOD"))
+            error = parse_mapping(value, &config->disk_mapping);
+        else if (!strcmp(key, "DISK_SERIAL"))
+            error = parse_serials(value, config);
+        else if (!strcmp(key, "BRIGHTNESS_POWER"))
+            error = parse_unsigned(value, 0, 255,
+                                   &config->power_brightness);
+        else if (!strcmp(key, "COLOR_POWER"))
+            error = parse_rgb(value, &config->power_color);
+        else if (!strcmp(key, "BLINK_TYPE_POWER"))
+            error = parse_power_mode(value, config);
+        else
+            continue;
+
+        if (error < 0) {
+            fprintf(stderr, "%s:%u: invalid value for %s\n",
+                    path, line_number, key);
+            result = error;
+            break;
+        }
+    }
+
+    if (ferror(file) && !result)
+        result = -(errno ? errno : EIO);
+    free(line);
+    fclose(file);
+    return result;
+}
+
+static int find_config_path(int argc, char **argv, const char **path,
+                            bool *explicit_path)
+{
+    int i;
+
+    *path = UGREEN_DEFAULT_CONFIG_PATH;
+    *explicit_path = false;
+    for (i = 1; i < argc; ++i) {
+        if (!strcmp(argv[i], "--config")) {
+            if (++i >= argc)
+                return -EINVAL;
+            *path = argv[i];
+            *explicit_path = true;
+        } else if (!strncmp(argv[i], "--config=", 9)) {
+            *path = argv[i] + 9;
+            *explicit_path = true;
+        }
+    }
+    return 0;
+}
+
+void config_usage(const char *argv0)
+{
+    fprintf(stderr,
+        "Usage: %s [options]\n\n"
+        "Unified event-driven UGREEN power, network, and disk LED daemon.\n\n"
+        "  -i, --interface IFACE       enable network monitoring on IFACE\n"
+        "  -o, --bpf-object PATH       BPF object (default: %s)\n"
+        "      --config PATH           configuration file (default: %s)\n"
+        "      --i2c-device PATH       override automatic I2C detection\n"
+        "      --interval-ms N         network event interval\n"
+        "      --pulse-ms N            network pulse width\n"
+        "      --rx-color R,G,B        network RX color\n"
+        "      --tx-color R,G,B        network TX color\n"
+        "      --brightness N          network brightness\n"
+        "      --disk-interval-ms N    disk event interval\n"
+        "      --disk-hold-ms N        disk idle deadline before steady state\n"
+        "      --disk-pulse-ms N       disk blink on/off pulse width\n"
+        "      --no-network            disable network monitoring\n"
+        "      --no-disks              disable disk monitoring\n"
+        "      --no-power              do not configure the power LED\n"
+        "  -v, --verbose               print discovery and activity events\n"
+        "  -h, --help                  show this help\n",
+        argv0, UGREEN_DEFAULT_BPF_OBJECT, UGREEN_DEFAULT_CONFIG_PATH);
+}
+
+int config_parse_options(int argc, char **argv, struct config *config)
+{
+    enum {
+        OPT_INTERVAL = 1000,
+        OPT_PULSE,
+        OPT_RX_COLOR,
+        OPT_TX_COLOR,
+        OPT_BRIGHTNESS,
+        OPT_I2C_DEVICE,
+        OPT_CONFIG,
+        OPT_DISK_INTERVAL,
+        OPT_DISK_HOLD,
+        OPT_DISK_PULSE,
+        OPT_NO_NETWORK,
+        OPT_NO_DISKS,
+        OPT_NO_POWER,
+    };
+    static const struct option options[] = {
+        {"interface", required_argument, NULL, 'i'},
+        {"bpf-object", required_argument, NULL, 'o'},
+        {"interval-ms", required_argument, NULL, OPT_INTERVAL},
+        {"pulse-ms", required_argument, NULL, OPT_PULSE},
+        {"rx-color", required_argument, NULL, OPT_RX_COLOR},
+        {"tx-color", required_argument, NULL, OPT_TX_COLOR},
+        {"brightness", required_argument, NULL, OPT_BRIGHTNESS},
+        {"i2c-device", required_argument, NULL, OPT_I2C_DEVICE},
+        {"config", required_argument, NULL, OPT_CONFIG},
+        {"disk-interval-ms", required_argument, NULL, OPT_DISK_INTERVAL},
+        {"disk-hold-ms", required_argument, NULL, OPT_DISK_HOLD},
+        {"disk-pulse-ms", required_argument, NULL, OPT_DISK_PULSE},
+        {"no-network", no_argument, NULL, OPT_NO_NETWORK},
+        {"no-disks", no_argument, NULL, OPT_NO_DISKS},
+        {"no-power", no_argument, NULL, OPT_NO_POWER},
+        {"verbose", no_argument, NULL, 'v'},
+        {"help", no_argument, NULL, 'h'},
+        {NULL, 0, NULL, 0},
+    };
+    const char *config_path;
+    bool explicit_config;
+    int error;
+
+    config_set_defaults(config);
+    error = find_config_path(argc, argv, &config_path, &explicit_config);
+    if (error < 0)
+        return error;
+    config->config_path = config_path;
+    error = config_load_file(config_path, config);
+    if (error < 0 && (error != -ENOENT || explicit_config)) {
+        if (error == -ENOENT)
+            fprintf(stderr, "configuration file '%s' does not exist\n",
+                    config_path);
+        else if (error != -EINVAL)
+            fprintf(stderr, "could not read configuration file '%s': %s\n",
+                    config_path, strerror(-error));
+        return error;
+    }
+
+    optind = 1;
+    for (;;) {
+        int option = getopt_long(argc, argv, "i:o:vh", options, NULL);
+        if (option == -1)
+            break;
+        error = 0;
+        switch (option) {
+        case 'i':
+            error = copy_interface(optarg, config);
+            break;
+        case 'o': config->bpf_object = optarg; break;
+        case 'v': config->verbose = true; break;
+        case 'h': config_usage(argv[0]); exit(EXIT_SUCCESS);
+        case OPT_CONFIG: config->config_path = optarg; break;
+        case OPT_I2C_DEVICE: config->i2c_device = optarg; break;
+        case OPT_NO_NETWORK: config->network_enabled = false; break;
+        case OPT_NO_DISKS: config->disks_enabled = false; break;
+        case OPT_NO_POWER: config->power_enabled = false; break;
+        case OPT_INTERVAL:
+            error = parse_unsigned(optarg, 1, 1000,
+                                   &config->network_interval_ms); break;
+        case OPT_PULSE:
+            error = parse_unsigned(optarg, 0, 1000,
+                                   &config->network_pulse_ms); break;
+        case OPT_RX_COLOR:
+            error = parse_rgb(optarg, &config->network_rx_color); break;
+        case OPT_TX_COLOR:
+            error = parse_rgb(optarg, &config->network_tx_color); break;
+        case OPT_BRIGHTNESS:
+            error = parse_unsigned(optarg, 0, 255,
+                                   &config->network_brightness); break;
+        case OPT_DISK_INTERVAL:
+            error = parse_unsigned(optarg, 1, 1000,
+                                   &config->disk_interval_ms); break;
+        case OPT_DISK_HOLD:
+            error = parse_unsigned(optarg, 1, 10000,
+                                   &config->disk_hold_ms); break;
+        case OPT_DISK_PULSE:
+            error = parse_unsigned(optarg, 1, 1000,
+                                   &config->disk_pulse_ms); break;
+        default:
+            return -EINVAL;
+        }
+        if (error < 0)
+            return error;
+    }
+
+    if (optind != argc || config->disk_pulse_ms >= config->disk_interval_ms ||
+        (!config->power_enabled && !config->disks_enabled &&
+         !config->network_enabled))
+        return -EINVAL;
+    return 0;
+}

--- a/ebpf/src/config.h
+++ b/ebpf/src/config.h
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_CONFIG_H
+#define UGREEN_CONFIG_H
+
+#include <stdbool.h>
+#include <net/if.h>
+
+#include "types.h"
+
+#define UGREEN_DEFAULT_BPF_OBJECT "./ugreen_led.bpf.o"
+#define UGREEN_DEFAULT_CONFIG_PATH "/etc/ugreen-leds.conf"
+#define UGREEN_MAX_SERIAL_LENGTH 128
+
+enum power_mode {
+    POWER_MODE_ON,
+    POWER_MODE_BLINK,
+    POWER_MODE_BREATH,
+};
+
+enum disk_mapping_method {
+    DISK_MAPPING_ATA,
+    DISK_MAPPING_HCTL,
+    DISK_MAPPING_SERIAL,
+};
+
+struct config {
+    char interface[IFNAMSIZ];
+    const char *bpf_object;
+    const char *config_path;
+    const char *i2c_device;
+    bool verbose;
+    bool network_enabled;
+    bool disks_enabled;
+    bool power_enabled;
+
+    unsigned network_interval_ms;
+    unsigned network_pulse_ms;
+    unsigned network_brightness;
+    struct rgb network_rx_color;
+    struct rgb network_tx_color;
+
+    unsigned disk_interval_ms;
+    unsigned disk_hold_ms;
+    unsigned disk_pulse_ms;
+    unsigned disk_brightness;
+    struct rgb disk_color;
+    struct rgb disk_colors[UGREEN_DISK_COUNT];
+    bool disk_color_set[UGREEN_DISK_COUNT];
+    bool disk_invert;
+    enum disk_mapping_method disk_mapping;
+    char disk_serials[UGREEN_DISK_COUNT][UGREEN_MAX_SERIAL_LENGTH];
+
+    unsigned power_brightness;
+    struct rgb power_color;
+    enum power_mode power_mode;
+    unsigned power_on_ms;
+    unsigned power_off_ms;
+};
+
+void config_set_defaults(struct config *config);
+int config_load_file(const char *path, struct config *config);
+int config_parse_options(int argc, char **argv, struct config *config);
+void config_usage(const char *argv0);
+
+static inline struct rgb config_disk_color(const struct config *config,
+                                           unsigned slot)
+{
+    return slot < UGREEN_DISK_COUNT && config->disk_color_set[slot]
+        ? config->disk_colors[slot] : config->disk_color;
+}
+
+#endif

--- a/ebpf/src/disk_layout.c
+++ b/ebpf/src/disk_layout.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "disk_layout.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "types.h"
+
+static bool product_starts_with(const char *product_name, const char *prefix)
+{
+    return !strncmp(product_name, prefix, strlen(prefix));
+}
+
+unsigned disk_layout_slot_count(const char *product_name)
+{
+    if (product_starts_with(product_name, "DXP2800"))
+        return 2;
+    if (product_starts_with(product_name, "DX4600") ||
+        product_starts_with(product_name, "DX4700") ||
+        product_starts_with(product_name, "DXP4800"))
+        return 4;
+    if (product_starts_with(product_name, "DXP6800"))
+        return 6;
+    return UGREEN_DISK_COUNT;
+}
+
+int disk_layout_hctl_slot(const char *product_name, unsigned slot_count,
+                          const char *device_path)
+{
+    const char *base = strrchr(device_path, '/');
+    unsigned host, channel, target, lun;
+    char tail;
+
+    base = base ? base + 1 : device_path;
+    if (sscanf(base, "%u:%u:%u:%u%c", &host, &channel, &target, &lun,
+               &tail) != 4 || channel || target || lun)
+        return -1;
+
+    if (product_starts_with(product_name, "DXP6800")) {
+        static const int slots[] = {4, 5, 0, 1, 2, 3};
+        return host < sizeof(slots) / sizeof(slots[0]) ? slots[host] : -1;
+    }
+    return host < slot_count ? (int)host : -1;
+}
+
+int disk_layout_ata_slot(const char *product_name, unsigned slot_count,
+                         const char *block_path)
+{
+    const char *cursor = block_path;
+    unsigned ata;
+
+    while ((cursor = strstr(cursor, "/ata")) != NULL) {
+        char tail;
+        if (sscanf(cursor, "/ata%u%c", &ata, &tail) >= 1) {
+            if (product_starts_with(product_name, "DXP6800")) {
+                static const int slots[] = {-1, 4, 5, 0, 1, 2, 3};
+                return ata < sizeof(slots) / sizeof(slots[0])
+                    ? slots[ata] : -1;
+            }
+            return ata >= 1 && ata <= slot_count ? (int)ata - 1 : -1;
+        }
+        cursor += 4;
+    }
+    return -1;
+}

--- a/ebpf/src/disk_layout.h
+++ b/ebpf/src/disk_layout.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_DISK_LAYOUT_H
+#define UGREEN_DISK_LAYOUT_H
+
+unsigned disk_layout_slot_count(const char *product_name);
+int disk_layout_hctl_slot(const char *product_name, unsigned slot_count,
+                          const char *device_path);
+int disk_layout_ata_slot(const char *product_name, unsigned slot_count,
+                         const char *block_path);
+
+#endif

--- a/ebpf/src/disk_led.c
+++ b/ebpf/src/disk_led.c
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: GPL-2.0
+#define _GNU_SOURCE
+
+#include "disk_led.h"
+#include "disk_layout.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/netlink.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+#define SYS_BLOCK "/sys/class/block"
+#define DMI_PRODUCT_NAME "/sys/class/dmi/id/product_name"
+#define KERNEL_MINOR_BITS 20U
+
+static uint64_t monotonic_ns(void)
+{
+    struct timespec time;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &time) < 0)
+        return 0;
+    return (uint64_t)time.tv_sec * 1000000000ULL + (uint64_t)time.tv_nsec;
+}
+
+static int read_line(const char *path, char *buffer, size_t length)
+{
+    FILE *file = fopen(path, "re");
+
+    if (!file)
+        return -errno;
+    if (!fgets(buffer, (int)length, file)) {
+        int error = ferror(file) ? -(errno ? errno : EIO) : -EIO;
+        fclose(file);
+        return error;
+    }
+    fclose(file);
+    buffer[strcspn(buffer, "\r\n")] = '\0';
+    return 0;
+}
+
+static int parse_dev(const char *name, uint32_t *dev, unsigned *major_out,
+                     unsigned *minor_out)
+{
+    char path[PATH_MAX];
+    char value[64];
+    unsigned major;
+    unsigned minor;
+    char tail;
+
+    if (snprintf(path, sizeof(path), SYS_BLOCK "/%s/dev", name) >=
+        (int)sizeof(path))
+        return -ENAMETOOLONG;
+    if (read_line(path, value, sizeof(value)) < 0)
+        return -ENOENT;
+    if (sscanf(value, "%u:%u%c", &major, &minor, &tail) != 2 ||
+        major >= (1U << (32U - KERNEL_MINOR_BITS)) ||
+        minor >= (1U << KERNEL_MINOR_BITS))
+        return -EINVAL;
+
+    *dev = (major << KERNEL_MINOR_BITS) | minor;
+    *major_out = major;
+    *minor_out = minor;
+    return 0;
+}
+
+static int read_udev_serial(unsigned major, unsigned minor,
+                            char *serial, size_t length)
+{
+    char path[PATH_MAX];
+    char *line = NULL;
+    size_t capacity = 0;
+    FILE *file;
+    int result = -ENOENT;
+
+    if (snprintf(path, sizeof(path), "/run/udev/data/b%u:%u",
+                 major, minor) >= (int)sizeof(path))
+        return -ENAMETOOLONG;
+    file = fopen(path, "re");
+    if (!file)
+        return -errno;
+
+    while (getline(&line, &capacity, file) >= 0) {
+        const char prefix[] = "E:ID_SERIAL_SHORT=";
+        if (!strncmp(line, prefix, sizeof(prefix) - 1)) {
+            char *value = line + sizeof(prefix) - 1;
+            value[strcspn(value, "\r\n")] = '\0';
+            if (strlen(value) >= length)
+                result = -ENAMETOOLONG;
+            else {
+                snprintf(serial, length, "%s", value);
+                result = 0;
+            }
+            break;
+        }
+    }
+    free(line);
+    fclose(file);
+    return result;
+}
+
+static int serial_slot(const struct disk_leds *disks,
+                       unsigned major, unsigned minor)
+{
+    char serial[UGREEN_MAX_SERIAL_LENGTH];
+    unsigned slot;
+
+    if (read_udev_serial(major, minor, serial, sizeof(serial)) < 0)
+        return -1;
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        if (disks->config->disk_serials[slot][0] &&
+            !strcmp(serial, disks->config->disk_serials[slot]))
+            return (int)slot;
+    }
+    return -1;
+}
+
+static int device_slot(const struct disk_leds *disks, const char *name,
+                       unsigned major, unsigned minor)
+{
+    char device_link[PATH_MAX];
+    char block_link[PATH_MAX];
+    char resolved[PATH_MAX];
+
+    if (disks->config->disk_mapping == DISK_MAPPING_SERIAL)
+        return serial_slot(disks, major, minor);
+
+    if (snprintf(device_link, sizeof(device_link), SYS_BLOCK "/%s/device",
+                 name) >= (int)sizeof(device_link) ||
+        !realpath(device_link, resolved))
+        return -1;
+    if (disks->config->disk_mapping == DISK_MAPPING_HCTL)
+        return disk_layout_hctl_slot(disks->product_name, disks->slot_count,
+                                     resolved);
+
+    if (snprintf(block_link, sizeof(block_link), SYS_BLOCK "/%s", name) >=
+        (int)sizeof(block_link) || !realpath(block_link, resolved))
+        return -1;
+    return disk_layout_ata_slot(disks->product_name, disks->slot_count,
+                                resolved);
+}
+
+static int discover(struct disk_leds *disks, struct disk_slot *found)
+{
+    struct dirent *entry;
+    DIR *directory = opendir(SYS_BLOCK);
+
+    if (!directory)
+        return -errno;
+    while ((entry = readdir(directory)) != NULL) {
+        char partition_path[PATH_MAX];
+        uint32_t dev;
+        unsigned major;
+        unsigned minor;
+        int slot;
+
+        if (entry->d_name[0] == '.')
+            continue;
+        if (snprintf(partition_path, sizeof(partition_path),
+                     SYS_BLOCK "/%s/partition", entry->d_name) >=
+            (int)sizeof(partition_path) || access(partition_path, F_OK) == 0)
+            continue;
+        if (parse_dev(entry->d_name, &dev, &major, &minor) < 0)
+            continue;
+        slot = device_slot(disks, entry->d_name, major, minor);
+        if (slot < 0 || (unsigned)slot >= disks->slot_count)
+            continue;
+        if (found[slot].present) {
+            fprintf(stderr, "multiple block devices map to disk%d; ignoring %s\n",
+                    slot + 1, entry->d_name);
+            continue;
+        }
+
+        found[slot].led_id = UGREEN_LED_DISK_FIRST + (uint8_t)slot;
+        found[slot].present = true;
+        found[slot].dev = dev;
+        if (strlen(entry->d_name) >= sizeof(found[slot].name))
+            continue;
+        memcpy(found[slot].name, entry->d_name, strlen(entry->d_name) + 1);
+    }
+    closedir(directory);
+    return 0;
+}
+
+static int set_steady(struct disk_leds *disks, struct disk_slot *slot)
+{
+    unsigned index = slot->led_id - UGREEN_LED_DISK_FIRST;
+    int error;
+
+    error = led_controller_set_color(disks->controller, slot->led_id,
+                                     config_disk_color(disks->config, index));
+    if (!error)
+        error = led_controller_set_brightness(
+            disks->controller, slot->led_id,
+            (uint8_t)disks->config->disk_brightness);
+    if (!error)
+        error = led_controller_set_on(disks->controller, slot->led_id,
+                                      disks->config->disk_invert);
+    return error;
+}
+
+static int arm_timer(struct disk_leds *disks)
+{
+    struct itimerspec timer = {0};
+    uint64_t earliest = UINT64_MAX;
+    unsigned slot;
+
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        if (disks->slots[slot].active &&
+            disks->slots[slot].deadline_ns < earliest)
+            earliest = disks->slots[slot].deadline_ns;
+    }
+    if (earliest != UINT64_MAX) {
+        timer.it_value.tv_sec = earliest / 1000000000ULL;
+        timer.it_value.tv_nsec = (long)(earliest % 1000000000ULL);
+    }
+    return timerfd_settime(disks->timer_fd, TFD_TIMER_ABSTIME,
+                           &timer, NULL) < 0 ? -errno : 0;
+}
+
+static int open_uevent_socket(void)
+{
+    struct sockaddr_nl address = {
+        .nl_family = AF_NETLINK,
+        .nl_pid = (uint32_t)getpid(),
+        .nl_groups = 1,
+    };
+    int fd = socket(AF_NETLINK,
+                    SOCK_DGRAM | SOCK_CLOEXEC | SOCK_NONBLOCK,
+                    NETLINK_KOBJECT_UEVENT);
+
+    if (fd < 0)
+        return -errno;
+    if (bind(fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
+        int error = -errno;
+        close(fd);
+        return error;
+    }
+    return fd;
+}
+
+static int rescan(struct disk_leds *disks)
+{
+    struct disk_slot found[UGREEN_DISK_COUNT] = {0};
+    int first_error = 0;
+    unsigned slot;
+    int error = discover(disks, found);
+
+    if (error < 0)
+        return error;
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        struct disk_slot *old = &disks->slots[slot];
+        struct disk_slot *new = &found[slot];
+
+        new->led_id = UGREEN_LED_DISK_FIRST + (uint8_t)slot;
+        if (old->present == new->present && old->dev == new->dev)
+            continue;
+
+        if (disks->config->verbose) {
+            if (new->present)
+                fprintf(stderr, "disk%d: %s dev=0x%x appeared\n",
+                        slot + 1, new->name, new->dev);
+            else
+                fprintf(stderr, "disk%d: device removed\n", slot + 1);
+        }
+        led_controller_invalidate(disks->controller, new->led_id);
+        if (new->present)
+            error = set_steady(disks, new);
+        else
+            error = led_controller_set_on(disks->controller,
+                                          new->led_id, false);
+        if (error < 0 && !first_error)
+            first_error = error;
+        *old = *new;
+    }
+    return first_error;
+}
+
+int disk_leds_init(struct disk_leds *disks,
+                   struct led_controller *controller,
+                   const struct config *config)
+{
+    unsigned slot;
+    int error;
+
+    memset(disks, 0, sizeof(*disks));
+    disks->controller = controller;
+    disks->config = config;
+    disks->timer_fd = -1;
+    disks->uevent_fd = -1;
+    if (read_line(DMI_PRODUCT_NAME, disks->product_name,
+                  sizeof(disks->product_name)) < 0)
+        snprintf(disks->product_name, sizeof(disks->product_name), "unknown");
+    disks->slot_count = disk_layout_slot_count(disks->product_name);
+    for (slot = 0; slot < UGREEN_DISK_COUNT; ++slot) {
+        disks->slots[slot].led_id = UGREEN_LED_DISK_FIRST + (uint8_t)slot;
+        disks->slots[slot].dev = UINT32_MAX;
+    }
+
+    disks->timer_fd = timerfd_create(CLOCK_MONOTONIC,
+                                     TFD_CLOEXEC | TFD_NONBLOCK);
+    if (disks->timer_fd < 0)
+        return -errno;
+    disks->uevent_fd = open_uevent_socket();
+    if (disks->uevent_fd < 0) {
+        error = disks->uevent_fd;
+        close(disks->timer_fd);
+        disks->timer_fd = -1;
+        return error;
+    }
+
+    if (config->verbose)
+        fprintf(stderr,
+                "disk discovery: model='%s' slots=%u mapping=%s "
+                "invert=%s interval=%ums pulse=%ums hold=%ums\n",
+                disks->product_name, disks->slot_count,
+                config->disk_mapping == DISK_MAPPING_ATA ? "ata" :
+                config->disk_mapping == DISK_MAPPING_HCTL ? "hctl" : "serial",
+                config->disk_invert ? "on" : "off",
+                config->disk_interval_ms, config->disk_pulse_ms,
+                config->disk_hold_ms);
+    return rescan(disks);
+}
+
+int disk_leds_sync_bpf(struct disk_leds *disks,
+                       struct bpf_runtime *runtime)
+{
+    unsigned slot;
+    int error = bpf_runtime_clear_disk_targets(runtime);
+
+    if (error < 0)
+        return error;
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        if (!disks->slots[slot].present)
+            continue;
+        error = bpf_runtime_set_disk_target(runtime, disks->slots[slot].dev,
+                                            disks->slots[slot].led_id);
+        if (error < 0)
+            return error;
+    }
+    return 0;
+}
+
+int disk_leds_handle_activity(struct disk_leds *disks, uint8_t led_id)
+{
+    struct disk_slot *slot;
+    unsigned index;
+    unsigned on_ms;
+    unsigned off_ms;
+    int error = 0;
+
+    if (led_id < UGREEN_LED_DISK_FIRST)
+        return -EINVAL;
+    index = led_id - UGREEN_LED_DISK_FIRST;
+    if (index >= disks->slot_count || !disks->slots[index].present)
+        return 0;
+    slot = &disks->slots[index];
+    slot->deadline_ns = monotonic_ns() +
+        (uint64_t)disks->config->disk_hold_ms * 1000000ULL;
+
+    if (!slot->active) {
+        if (disks->config->disk_invert) {
+            off_ms = disks->config->disk_pulse_ms;
+            on_ms = disks->config->disk_interval_ms - off_ms;
+        } else {
+            on_ms = disks->config->disk_pulse_ms;
+            off_ms = disks->config->disk_interval_ms - on_ms;
+        }
+        error = led_controller_set_blink(disks->controller, led_id,
+                                         (uint16_t)on_ms,
+                                         (uint16_t)off_ms, false);
+        if (error < 0) {
+            fprintf(stderr, "failed to start disk%d activity blink: %s\n",
+                    index + 1, strerror(-error));
+            led_controller_invalidate(disks->controller, led_id);
+        } else {
+            slot->active = true;
+            if (disks->config->verbose)
+                fprintf(stderr, "disk%d activity\n", index + 1);
+        }
+    }
+    if (slot->active)
+        return arm_timer(disks);
+    return 0;
+}
+
+int disk_leds_handle_timer(struct disk_leds *disks)
+{
+    uint64_t expirations;
+    uint64_t now = monotonic_ns();
+    unsigned slot;
+    ssize_t size = read(disks->timer_fd, &expirations, sizeof(expirations));
+
+    if (size < 0 && errno != EAGAIN)
+        return -errno;
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        struct disk_slot *disk = &disks->slots[slot];
+        int error;
+
+        if (!disk->active || disk->deadline_ns > now)
+            continue;
+        error = set_steady(disks, disk);
+        if (error < 0) {
+            fprintf(stderr, "failed to restore disk%d LED: %s; continuing\n",
+                    slot + 1, strerror(-error));
+            led_controller_invalidate(disks->controller, disk->led_id);
+        }
+        disk->active = false;
+        disk->deadline_ns = 0;
+    }
+    return arm_timer(disks);
+}
+
+static bool is_block_uevent(char *buffer, ssize_t length)
+{
+    bool block = false;
+    bool relevant_action = false;
+    char *field = buffer;
+    char *end = buffer + length;
+
+    while (field < end && *field) {
+        if (!strcmp(field, "SUBSYSTEM=block"))
+            block = true;
+        if (!strcmp(field, "ACTION=add") || !strcmp(field, "ACTION=remove") ||
+            !strcmp(field, "ACTION=change"))
+            relevant_action = true;
+        field += strlen(field) + 1;
+    }
+    return block && relevant_action;
+}
+
+int disk_leds_handle_uevent(struct disk_leds *disks,
+                            struct bpf_runtime *runtime)
+{
+    char buffer[8192];
+    bool rescan_needed = false;
+
+    for (;;) {
+        ssize_t length = recv(disks->uevent_fd, buffer, sizeof(buffer) - 1,
+                              MSG_DONTWAIT);
+        if (length < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                break;
+            return -errno;
+        }
+        buffer[length] = '\0';
+        if (is_block_uevent(buffer, length))
+            rescan_needed = true;
+    }
+    if (!rescan_needed)
+        return 0;
+    if (rescan(disks) < 0)
+        fprintf(stderr, "disk rescan encountered an LED update failure\n");
+    return disk_leds_sync_bpf(disks, runtime);
+}
+
+void disk_leds_cleanup(struct disk_leds *disks)
+{
+    unsigned slot;
+
+    for (slot = 0; slot < disks->slot_count; ++slot) {
+        if (disks->slots[slot].present)
+            (void)set_steady(disks, &disks->slots[slot]);
+    }
+    if (disks->timer_fd >= 0)
+        close(disks->timer_fd);
+    if (disks->uevent_fd >= 0)
+        close(disks->uevent_fd);
+    disks->timer_fd = -1;
+    disks->uevent_fd = -1;
+}

--- a/ebpf/src/disk_led.h
+++ b/ebpf/src/disk_led.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_DISK_LED_H
+#define UGREEN_DISK_LED_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "bpf_runtime.h"
+#include "config.h"
+#include "led_controller.h"
+#include "types.h"
+
+struct disk_slot {
+    uint8_t led_id;
+    bool present;
+    bool active;
+    uint32_t dev;
+    char name[64];
+    uint64_t deadline_ns;
+};
+
+struct disk_leds {
+    struct disk_slot slots[UGREEN_DISK_COUNT];
+    struct led_controller *controller;
+    const struct config *config;
+    unsigned slot_count;
+    char product_name[128];
+    int timer_fd;
+    int uevent_fd;
+};
+
+int disk_leds_init(struct disk_leds *disks,
+                   struct led_controller *controller,
+                   const struct config *config);
+int disk_leds_sync_bpf(struct disk_leds *disks,
+                       struct bpf_runtime *runtime);
+int disk_leds_handle_activity(struct disk_leds *disks, uint8_t led_id);
+int disk_leds_handle_timer(struct disk_leds *disks);
+int disk_leds_handle_uevent(struct disk_leds *disks,
+                            struct bpf_runtime *runtime);
+void disk_leds_cleanup(struct disk_leds *disks);
+
+#endif

--- a/ebpf/src/led_controller.c
+++ b/ebpf/src/led_controller.c
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0
+#define _GNU_SOURCE
+
+#include "led_controller.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/i2c-dev.h>
+#include <linux/i2c.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define UGREEN_LED_I2C_ADDR 0x3a
+#define UGREEN_I2C_SYSFS "/sys/class/i2c-dev"
+#define UGREEN_I2C_ADAPTER_PREFIX "SMBus I801 adapter"
+#define COMMAND_RETRY_COUNT 5U
+#define COMMAND_INITIAL_DELAY_US 1000U
+#define COMMAND_RETRY_DELAY_US 30000U
+#define COMMAND_STATUS_DELAY_US 2000U
+
+static int i2c_write_block(int fd, uint8_t command,
+                           const uint8_t *data, size_t size)
+{
+    union i2c_smbus_data smbus_data = {0};
+    struct i2c_smbus_ioctl_data ioctl_data;
+    size_t i;
+
+    if (size > I2C_SMBUS_BLOCK_MAX)
+        return -EMSGSIZE;
+
+    smbus_data.block[0] = (uint8_t)size;
+    for (i = 0; i < size; ++i)
+        smbus_data.block[i + 1] = data[i];
+
+    ioctl_data.read_write = I2C_SMBUS_WRITE;
+    ioctl_data.command = command;
+    ioctl_data.size = I2C_SMBUS_I2C_BLOCK_DATA;
+    ioctl_data.data = &smbus_data;
+
+    return ioctl(fd, I2C_SMBUS, &ioctl_data) < 0 ? -errno : 0;
+}
+
+static int i2c_read_byte(int fd, uint8_t command, uint8_t *value)
+{
+    union i2c_smbus_data smbus_data = {0};
+    struct i2c_smbus_ioctl_data ioctl_data = {
+        .read_write = I2C_SMBUS_READ,
+        .command = command,
+        .size = I2C_SMBUS_BYTE_DATA,
+        .data = &smbus_data,
+    };
+
+    if (ioctl(fd, I2C_SMBUS, &ioctl_data) < 0)
+        return -errno;
+    *value = smbus_data.byte & 0xff;
+    return 0;
+}
+
+static int read_first_line(const char *path, char *buffer, size_t length)
+{
+    FILE *file = fopen(path, "re");
+
+    if (!file)
+        return -errno;
+    if (!fgets(buffer, (int)length, file)) {
+        int error = ferror(file) ? -(errno ? errno : EIO) : -EIO;
+        fclose(file);
+        return error;
+    }
+    fclose(file);
+    buffer[strcspn(buffer, "\r\n")] = '\0';
+    return 0;
+}
+
+static int find_i2c_device(char *output, size_t length)
+{
+    struct dirent *entry;
+    DIR *directory = opendir(UGREEN_I2C_SYSFS);
+    int result = -ENOENT;
+
+    if (!directory)
+        return -errno;
+
+    while ((entry = readdir(directory)) != NULL) {
+        char name_path[PATH_MAX];
+        char adapter_name[256];
+        int written;
+
+        if (strncmp(entry->d_name, "i2c-", 4) != 0)
+            continue;
+        written = snprintf(name_path, sizeof(name_path), "%s/%s/device/name",
+                           UGREEN_I2C_SYSFS, entry->d_name);
+        if (written < 0 || (size_t)written >= sizeof(name_path))
+            continue;
+        if (read_first_line(name_path, adapter_name, sizeof(adapter_name)) < 0)
+            continue;
+        if (strncmp(adapter_name, UGREEN_I2C_ADAPTER_PREFIX,
+                    strlen(UGREEN_I2C_ADAPTER_PREFIX)) != 0)
+            continue;
+
+        written = snprintf(output, length, "/dev/%s", entry->d_name);
+        result = written < 0 || (size_t)written >= length ? -ENAMETOOLONG : 0;
+        break;
+    }
+
+    closedir(directory);
+    return result;
+}
+
+int led_controller_open(struct led_controller *controller,
+                        const char *override_path)
+{
+    char detected[PATH_MAX];
+    const char *path = override_path;
+    int error;
+
+    memset(controller, 0, sizeof(*controller));
+    controller->fd = -1;
+    if (!path) {
+        error = find_i2c_device(detected, sizeof(detected));
+        if (error < 0)
+            return error;
+        path = detected;
+    }
+
+    controller->fd = open(path, O_RDWR | O_CLOEXEC);
+    if (controller->fd < 0)
+        return -errno;
+    if (ioctl(controller->fd, I2C_SLAVE, UGREEN_LED_I2C_ADDR) < 0) {
+        error = -errno;
+        led_controller_close(controller);
+        return error;
+    }
+
+    snprintf(controller->path, sizeof(controller->path), "%s", path);
+    return 0;
+}
+
+void led_controller_close(struct led_controller *controller)
+{
+    if (controller->fd >= 0)
+        close(controller->fd);
+    controller->fd = -1;
+}
+
+void led_controller_invalidate(struct led_controller *controller,
+                               uint8_t led_id)
+{
+    if (led_id >= UGREEN_LED_COUNT)
+        return;
+    memset(&controller->cache[led_id], 0,
+           sizeof(controller->cache[led_id]));
+}
+
+static unsigned checksum(const uint8_t *data, size_t size)
+{
+    unsigned sum = 0;
+    size_t i;
+
+    for (i = 0; i < size; ++i)
+        sum += data[i];
+    return sum;
+}
+
+static int change_status_once(struct led_controller *controller,
+                              uint8_t led_id, uint8_t command,
+                              uint8_t p0, uint8_t p1,
+                              uint8_t p2, uint8_t p3)
+{
+    uint8_t data[12] = {
+        0x00, 0xa0, 0x01, 0x00, 0x00, command,
+        p0, p1, p2, p3, 0x00, 0x00,
+    };
+    unsigned sum = checksum(data, 10);
+
+    data[10] = (uint8_t)(sum >> 8);
+    data[11] = (uint8_t)sum;
+    data[0] = led_id;
+    return i2c_write_block(controller->fd, led_id, data, sizeof(data));
+}
+
+static int change_status(struct led_controller *controller, uint8_t led_id,
+                         uint8_t command, uint8_t p0, uint8_t p1,
+                         uint8_t p2, uint8_t p3)
+{
+    const char *stage = "unknown stage";
+    uint8_t accepted = 0;
+    unsigned attempt;
+    int error = -EIO;
+
+    if (led_id >= UGREEN_LED_COUNT)
+        return -EINVAL;
+
+    for (attempt = 0; attempt < COMMAND_RETRY_COUNT; ++attempt) {
+        if (usleep(attempt ? COMMAND_RETRY_DELAY_US
+                           : COMMAND_INITIAL_DELAY_US) < 0 && errno != EINTR)
+            return -errno;
+
+        error = change_status_once(controller, led_id, command,
+                                   p0, p1, p2, p3);
+        if (error < 0) {
+            stage = "SMBus write";
+            continue;
+        }
+        if (usleep(COMMAND_STATUS_DELAY_US) < 0 && errno != EINTR)
+            return -errno;
+
+        error = i2c_read_byte(controller->fd, 0x80, &accepted);
+        if (!error && accepted == 1)
+            return 0;
+        if (error < 0) {
+            stage = "MCU acknowledgement read";
+        } else {
+            stage = "MCU command rejection";
+            error = -EREMOTEIO;
+        }
+    }
+
+    led_controller_invalidate(controller, led_id);
+    fprintf(stderr,
+            "LED id=%u command=0x%02x failed after %u attempts during %s: "
+            "%s (last acknowledgement=0x%02x)\n",
+            led_id, command, COMMAND_RETRY_COUNT, stage,
+            strerror(-error), accepted);
+    return error;
+}
+
+int led_controller_set_color(struct led_controller *controller,
+                             uint8_t led_id, struct rgb color)
+{
+    struct led_cache *cache;
+    int error;
+
+    if (led_id >= UGREEN_LED_COUNT)
+        return -EINVAL;
+    cache = &controller->cache[led_id];
+    if (cache->color_valid && rgb_equal(cache->color, color))
+        return 0;
+
+    error = change_status(controller, led_id, 0x02,
+                          color.r, color.g, color.b, 0);
+    if (!error) {
+        cache->color = color;
+        cache->color_valid = true;
+    }
+    return error;
+}
+
+int led_controller_set_brightness(struct led_controller *controller,
+                                  uint8_t led_id, uint8_t brightness)
+{
+    struct led_cache *cache;
+    int error;
+
+    if (led_id >= UGREEN_LED_COUNT)
+        return -EINVAL;
+    cache = &controller->cache[led_id];
+    if (cache->brightness_valid && cache->brightness == brightness)
+        return 0;
+
+    error = change_status(controller, led_id, 0x01, brightness, 0, 0, 0);
+    if (!error) {
+        cache->brightness = brightness;
+        cache->brightness_valid = true;
+    }
+    return error;
+}
+
+int led_controller_set_on(struct led_controller *controller,
+                          uint8_t led_id, bool on)
+{
+    struct led_cache *cache;
+    enum led_mode mode = on ? LED_MODE_ON : LED_MODE_OFF;
+    int error;
+
+    if (led_id >= UGREEN_LED_COUNT)
+        return -EINVAL;
+    cache = &controller->cache[led_id];
+    if (cache->mode == mode)
+        return 0;
+
+    error = change_status(controller, led_id, 0x03, on ? 1 : 0, 0, 0, 0);
+    if (!error)
+        cache->mode = mode;
+    return error;
+}
+
+int led_controller_set_blink(struct led_controller *controller,
+                             uint8_t led_id, uint16_t on_ms,
+                             uint16_t off_ms, bool breath)
+{
+    struct led_cache *cache;
+    enum led_mode mode = breath ? LED_MODE_BREATH : LED_MODE_BLINK;
+    uint16_t cycle = on_ms + off_ms;
+    int error;
+
+    if (led_id >= UGREEN_LED_COUNT || cycle < on_ms)
+        return -EINVAL;
+    cache = &controller->cache[led_id];
+    if (cache->mode == mode && cache->on_ms == on_ms &&
+        cache->off_ms == off_ms)
+        return 0;
+
+    error = change_status(controller, led_id, breath ? 0x05 : 0x04,
+                          (uint8_t)(cycle >> 8), (uint8_t)cycle,
+                          (uint8_t)(on_ms >> 8), (uint8_t)on_ms);
+    if (!error) {
+        cache->mode = mode;
+        cache->on_ms = on_ms;
+        cache->off_ms = off_ms;
+    }
+    return error;
+}

--- a/ebpf/src/led_controller.h
+++ b/ebpf/src/led_controller.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_LED_CONTROLLER_H
+#define UGREEN_LED_CONTROLLER_H
+
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "types.h"
+
+enum led_mode {
+    LED_MODE_UNKNOWN,
+    LED_MODE_OFF,
+    LED_MODE_ON,
+    LED_MODE_BLINK,
+    LED_MODE_BREATH,
+};
+
+struct led_cache {
+    bool color_valid;
+    bool brightness_valid;
+    struct rgb color;
+    uint8_t brightness;
+    enum led_mode mode;
+    uint16_t on_ms;
+    uint16_t off_ms;
+};
+
+struct led_controller {
+    int fd;
+    char path[PATH_MAX];
+    struct led_cache cache[UGREEN_LED_COUNT];
+};
+
+int led_controller_open(struct led_controller *controller,
+                        const char *override_path);
+void led_controller_close(struct led_controller *controller);
+void led_controller_invalidate(struct led_controller *controller,
+                               uint8_t led_id);
+int led_controller_set_color(struct led_controller *controller,
+                             uint8_t led_id, struct rgb color);
+int led_controller_set_brightness(struct led_controller *controller,
+                                  uint8_t led_id, uint8_t brightness);
+int led_controller_set_on(struct led_controller *controller,
+                          uint8_t led_id, bool on);
+int led_controller_set_blink(struct led_controller *controller,
+                             uint8_t led_id, uint16_t on_ms,
+                             uint16_t off_ms, bool breath);
+
+#endif

--- a/ebpf/src/main.c
+++ b/ebpf/src/main.c
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-2.0
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/signalfd.h>
+#include <unistd.h>
+
+#include "bpf_runtime.h"
+#include "config.h"
+#include "disk_led.h"
+#include "led_controller.h"
+#include "network_led.h"
+#include "power_led.h"
+#include "ugreen_bpf_shared.h"
+
+struct app {
+    struct config config;
+    struct led_controller controller;
+    struct network_led network;
+    struct disk_leds disks;
+    struct bpf_runtime bpf;
+    int signal_fd;
+    bool network_initialized;
+    bool disks_initialized;
+    bool bpf_started;
+};
+
+static int set_memlock_rlimit(void)
+{
+    struct rlimit limit = {RLIM_INFINITY, RLIM_INFINITY};
+
+    if (setrlimit(RLIMIT_MEMLOCK, &limit) == 0 || errno == EPERM)
+        return 0;
+    return -errno;
+}
+
+static int open_signal_fd(void)
+{
+    sigset_t mask;
+
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGINT);
+    sigaddset(&mask, SIGTERM);
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0)
+        return -errno;
+    return signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
+}
+
+static int consume_signal(int fd)
+{
+    struct signalfd_siginfo signal;
+    ssize_t size = read(fd, &signal, sizeof(signal));
+
+    if (size < 0)
+        return errno == EAGAIN ? 0 : -errno;
+    if ((size_t)size != sizeof(signal))
+        return -EIO;
+    return signal.ssi_signo == SIGINT || signal.ssi_signo == SIGTERM ? 1 : 0;
+}
+
+static int handle_bpf_event(void *context, void *data, size_t size)
+{
+    struct app *app = context;
+    const struct ugreen_led_event *event = data;
+
+    if (size < sizeof(*event)) {
+        fprintf(stderr, "short BPF event (%zu bytes)\n", size);
+        return 0;
+    }
+    switch (event->kind) {
+    case UGREEN_EVENT_NETWORK:
+        if (app->network_initialized)
+            network_led_add_sample(&app->network, event->first_bytes,
+                                   event->second_bytes);
+        break;
+    case UGREEN_EVENT_DISK:
+        if (app->disks_initialized)
+            (void)disk_leds_handle_activity(&app->disks, event->led_id);
+        break;
+    default:
+        fprintf(stderr, "unknown BPF event kind %u\n", event->kind);
+        break;
+    }
+    return 0;
+}
+
+static int run_event_loop(struct app *app)
+{
+    enum { SIGNAL_FD, NETWORK_FD, DISK_TIMER_FD, UEVENT_FD, BPF_FD, FD_COUNT };
+    struct pollfd fds[FD_COUNT];
+
+    for (;;) {
+        int result;
+        int error;
+
+        fds[SIGNAL_FD] = (struct pollfd){app->signal_fd, POLLIN, 0};
+        fds[NETWORK_FD] = (struct pollfd){
+            app->network_initialized ? app->network.timer_fd : -1, POLLIN, 0};
+        fds[DISK_TIMER_FD] = (struct pollfd){
+            app->disks_initialized ? app->disks.timer_fd : -1, POLLIN, 0};
+        fds[UEVENT_FD] = (struct pollfd){
+            app->disks_initialized ? app->disks.uevent_fd : -1, POLLIN, 0};
+        fds[BPF_FD] = (struct pollfd){
+            app->bpf_started ? bpf_runtime_epoll_fd(&app->bpf) : -1,
+            POLLIN, 0};
+
+        result = poll(fds, FD_COUNT, -1);
+        if (result < 0) {
+            if (errno == EINTR)
+                continue;
+            return -errno;
+        }
+
+        if (fds[SIGNAL_FD].revents & POLLIN) {
+            error = consume_signal(app->signal_fd);
+            if (error != 0)
+                return error < 0 ? error : 0;
+        }
+        if (fds[NETWORK_FD].revents & POLLIN) {
+            error = network_led_handle_timer(&app->network);
+            if (error < 0)
+                return error;
+        }
+        if (fds[DISK_TIMER_FD].revents & POLLIN) {
+            error = disk_leds_handle_timer(&app->disks);
+            if (error < 0)
+                return error;
+        }
+        if (fds[UEVENT_FD].revents & POLLIN) {
+            error = disk_leds_handle_uevent(&app->disks, &app->bpf);
+            if (error < 0)
+                return error;
+        }
+        if (fds[BPF_FD].revents & POLLIN) {
+            error = bpf_runtime_consume(&app->bpf);
+            if (error < 0)
+                return error;
+            if (app->network_initialized) {
+                error = network_led_render(&app->network);
+                if (error < 0)
+                    return error;
+            }
+        }
+
+        for (unsigned i = 0; i < FD_COUNT; ++i) {
+            if (fds[i].fd >= 0 &&
+                (fds[i].revents & (POLLERR | POLLHUP | POLLNVAL)))
+                return -EIO;
+        }
+    }
+}
+
+int main(int argc, char **argv)
+{
+    struct app app;
+    int error = 0;
+
+    memset(&app, 0, sizeof(app));
+    app.controller.fd = -1;
+    app.signal_fd = -1;
+
+    if (config_parse_options(argc, argv, &app.config) < 0) {
+        config_usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+    error = set_memlock_rlimit();
+    if (error < 0) {
+        fprintf(stderr, "failed to raise memlock limit: %s\n", strerror(-error));
+        goto cleanup;
+    }
+    app.signal_fd = open_signal_fd();
+    if (app.signal_fd < 0) {
+        error = app.signal_fd;
+        fprintf(stderr, "failed to create signal fd: %s\n", strerror(-error));
+        goto cleanup;
+    }
+    error = led_controller_open(&app.controller, app.config.i2c_device);
+    if (error < 0) {
+        fprintf(stderr,
+                "could not open UGREEN LED MCU: %s\n"
+                "Is i2c-dev loaded and led_ugreen unloaded?\n",
+                strerror(-error));
+        goto cleanup;
+    }
+
+    if (app.config.power_enabled) {
+        error = power_led_apply(&app.controller, &app.config);
+        if (error < 0) {
+            fprintf(stderr, "failed to initialize power LED: %s\n",
+                    strerror(-error));
+            goto cleanup;
+        }
+    }
+    if (app.config.disks_enabled) {
+        error = disk_leds_init(&app.disks, &app.controller, &app.config);
+        if (error < 0) {
+            fprintf(stderr, "failed to initialize disk LEDs: %s\n",
+                    strerror(-error));
+            goto cleanup;
+        }
+        app.disks_initialized = true;
+    }
+    if (app.config.network_enabled) {
+        error = network_led_init(&app.network, &app.controller, &app.config);
+        if (error < 0) {
+            fprintf(stderr, "failed to initialize network LED: %s\n",
+                    strerror(-error));
+            goto cleanup;
+        }
+        app.network_initialized = true;
+    }
+
+    if (app.config.network_enabled || app.config.disks_enabled) {
+        error = bpf_runtime_start(&app.bpf, &app.config,
+                                  handle_bpf_event, &app);
+        if (error < 0) {
+            fprintf(stderr, "failed to start BPF collectors from '%s': %s\n",
+                    app.config.bpf_object, strerror(-error));
+            goto cleanup;
+        }
+        app.bpf_started = true;
+        if (app.disks_initialized) {
+            error = disk_leds_sync_bpf(&app.disks, &app.bpf);
+            if (error < 0) {
+                fprintf(stderr, "failed to configure disk BPF map: %s\n",
+                        strerror(-error));
+                goto cleanup;
+            }
+        }
+    }
+
+    fprintf(stderr, "ugreen-ledd started: power=%s network=%s disks=%s "
+                    "i2c=%s config=%s\n",
+            app.config.power_enabled ? "on" : "off",
+            app.config.network_enabled ? app.config.interface : "off",
+            app.config.disks_enabled ? "on" : "off",
+            app.controller.path, app.config.config_path);
+    error = run_event_loop(&app);
+    if (error < 0)
+        fprintf(stderr, "event loop failed: %s\n", strerror(-error));
+
+cleanup:
+    if (app.bpf_started)
+        bpf_runtime_stop(&app.bpf);
+    if (app.network_initialized)
+        network_led_cleanup(&app.network);
+    if (app.disks_initialized)
+        disk_leds_cleanup(&app.disks);
+    if (app.signal_fd >= 0)
+        close(app.signal_fd);
+    led_controller_close(&app.controller);
+    return error < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/ebpf/src/network_led.c
+++ b/ebpf/src/network_led.c
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "network_led.h"
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+
+static uint64_t saturating_add(uint64_t a, uint64_t b)
+{
+    return UINT64_MAX - a < b ? UINT64_MAX : a + b;
+}
+
+static int arm_timer(struct network_led *network)
+{
+    struct itimerspec timer = {0};
+
+    timer.it_value.tv_sec = network->config->network_pulse_ms / 1000;
+    timer.it_value.tv_nsec =
+        (long)(network->config->network_pulse_ms % 1000) * 1000000L;
+    if (!timer.it_value.tv_sec && !timer.it_value.tv_nsec)
+        timer.it_value.tv_nsec = 1;
+    return timerfd_settime(network->timer_fd, 0, &timer, NULL) < 0
+        ? -errno : 0;
+}
+
+int network_led_init(struct network_led *network,
+                     struct led_controller *controller,
+                     const struct config *config)
+{
+    int error;
+
+    memset(network, 0, sizeof(*network));
+    network->controller = controller;
+    network->config = config;
+    network->timer_fd = timerfd_create(CLOCK_MONOTONIC,
+                                       TFD_CLOEXEC | TFD_NONBLOCK);
+    if (network->timer_fd < 0)
+        return -errno;
+
+    error = led_controller_set_brightness(controller, UGREEN_LED_NETWORK,
+                                           (uint8_t)config->network_brightness);
+    if (!error)
+        error = led_controller_set_on(controller, UGREEN_LED_NETWORK, false);
+    if (error < 0) {
+        close(network->timer_fd);
+        network->timer_fd = -1;
+    }
+    return error;
+}
+
+void network_led_add_sample(struct network_led *network,
+                            uint64_t rx_bytes, uint64_t tx_bytes)
+{
+    network->pending_rx_bytes =
+        saturating_add(network->pending_rx_bytes, rx_bytes);
+    network->pending_tx_bytes =
+        saturating_add(network->pending_tx_bytes, tx_bytes);
+
+    if (network->config->verbose)
+        fprintf(stderr, "network sample rx=%llu tx=%llu\n",
+                (unsigned long long)rx_bytes,
+                (unsigned long long)tx_bytes);
+}
+
+int network_led_render(struct network_led *network)
+{
+    uint64_t rx_bytes;
+    uint64_t tx_bytes;
+    struct rgb color;
+    bool rx;
+    int error;
+
+    if (network->led_on)
+        return 0;
+    rx_bytes = network->pending_rx_bytes;
+    tx_bytes = network->pending_tx_bytes;
+    if (!rx_bytes && !tx_bytes)
+        return 0;
+
+    network->pending_rx_bytes = 0;
+    network->pending_tx_bytes = 0;
+    rx = scheduler_choose_rx(&network->scheduler, rx_bytes, tx_bytes);
+    color = rx ? network->config->network_rx_color
+               : network->config->network_tx_color;
+
+    if (network->config->verbose)
+        fprintf(stderr,
+                "network pulse sample-rx=%llu sample-tx=%llu "
+                "pulses-rx=%llu pulses-tx=%llu -> %s\n",
+                (unsigned long long)rx_bytes,
+                (unsigned long long)tx_bytes,
+                (unsigned long long)network->scheduler.rx_pulses,
+                (unsigned long long)network->scheduler.tx_pulses,
+                rx ? "RX" : "TX");
+
+    error = led_controller_set_color(network->controller,
+                                     UGREEN_LED_NETWORK, color);
+    if (!error)
+        error = led_controller_set_on(network->controller,
+                                      UGREEN_LED_NETWORK, true);
+    if (error < 0) {
+        fprintf(stderr, "failed to start network LED pulse: %s; dropping pulse\n",
+                strerror(-error));
+        led_controller_invalidate(network->controller, UGREEN_LED_NETWORK);
+        network->led_on = false;
+        return 0;
+    }
+    network->led_on = true;
+
+    error = arm_timer(network);
+    if (error < 0) {
+        (void)led_controller_set_on(network->controller,
+                                    UGREEN_LED_NETWORK, false);
+        network->led_on = false;
+    }
+    return error;
+}
+
+int network_led_handle_timer(struct network_led *network)
+{
+    uint64_t expirations;
+    ssize_t size = read(network->timer_fd, &expirations, sizeof(expirations));
+    int error;
+
+    if (size < 0 && errno != EAGAIN)
+        return -errno;
+    if (!network->led_on)
+        return 0;
+
+    error = led_controller_set_on(network->controller,
+                                  UGREEN_LED_NETWORK, false);
+    if (error < 0) {
+        fprintf(stderr, "failed to finish network LED pulse: %s; continuing\n",
+                strerror(-error));
+        led_controller_invalidate(network->controller, UGREEN_LED_NETWORK);
+    }
+    network->led_on = false;
+    return network_led_render(network);
+}
+
+void network_led_cleanup(struct network_led *network)
+{
+    if (network->controller)
+        (void)led_controller_set_on(network->controller,
+                                    UGREEN_LED_NETWORK, false);
+    if (network->timer_fd >= 0)
+        close(network->timer_fd);
+    network->timer_fd = -1;
+}

--- a/ebpf/src/network_led.h
+++ b/ebpf/src/network_led.h
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_NETWORK_LED_H
+#define UGREEN_NETWORK_LED_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "config.h"
+#include "led_controller.h"
+#include "scheduler.h"
+
+struct network_led {
+    struct pulse_scheduler scheduler;
+    struct led_controller *controller;
+    const struct config *config;
+    uint64_t pending_rx_bytes;
+    uint64_t pending_tx_bytes;
+    bool led_on;
+    int timer_fd;
+};
+
+int network_led_init(struct network_led *network,
+                     struct led_controller *controller,
+                     const struct config *config);
+void network_led_add_sample(struct network_led *network,
+                            uint64_t rx_bytes, uint64_t tx_bytes);
+int network_led_render(struct network_led *network);
+int network_led_handle_timer(struct network_led *network);
+void network_led_cleanup(struct network_led *network);
+
+#endif

--- a/ebpf/src/power_led.c
+++ b/ebpf/src/power_led.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "power_led.h"
+
+int power_led_apply(struct led_controller *controller,
+                    const struct config *config)
+{
+    int error;
+
+    error = led_controller_set_color(controller, UGREEN_LED_POWER,
+                                     config->power_color);
+    if (!error)
+        error = led_controller_set_brightness(
+            controller, UGREEN_LED_POWER, (uint8_t)config->power_brightness);
+    if (error < 0)
+        return error;
+
+    switch (config->power_mode) {
+    case POWER_MODE_ON:
+        return led_controller_set_on(controller, UGREEN_LED_POWER, true);
+    case POWER_MODE_BLINK:
+        return led_controller_set_blink(
+            controller, UGREEN_LED_POWER,
+            (uint16_t)config->power_on_ms,
+            (uint16_t)config->power_off_ms, false);
+    case POWER_MODE_BREATH:
+        return led_controller_set_blink(
+            controller, UGREEN_LED_POWER,
+            (uint16_t)config->power_on_ms,
+            (uint16_t)config->power_off_ms, true);
+    }
+    return -1;
+}

--- a/ebpf/src/power_led.h
+++ b/ebpf/src/power_led.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_POWER_LED_H
+#define UGREEN_POWER_LED_H
+
+#include "config.h"
+#include "led_controller.h"
+
+int power_led_apply(struct led_controller *controller,
+                    const struct config *config);
+
+#endif

--- a/ebpf/src/scheduler.c
+++ b/ebpf/src/scheduler.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "scheduler.h"
+
+#include <stdint.h>
+
+static uint64_t saturating_add_u64(uint64_t a, uint64_t b)
+{
+    return UINT64_MAX - a < b ? UINT64_MAX : a + b;
+}
+
+bool scheduler_choose_rx(struct pulse_scheduler *scheduler,
+                         uint64_t rx_bytes, uint64_t tx_bytes)
+{
+    long double total_bytes;
+    bool rx;
+
+    if (!tx_bytes) {
+        rx = true;
+    } else if (!rx_bytes) {
+        rx = false;
+    } else {
+        total_bytes = (long double)rx_bytes + (long double)tx_bytes;
+        scheduler->rx_credit += (long double)rx_bytes / total_bytes;
+        scheduler->tx_credit += (long double)tx_bytes / total_bytes;
+
+        rx = scheduler->rx_credit >= scheduler->tx_credit;
+        if (rx)
+            scheduler->rx_credit -= 1.0L;
+        else
+            scheduler->tx_credit -= 1.0L;
+    }
+
+    if (rx)
+        scheduler->rx_pulses = saturating_add_u64(scheduler->rx_pulses, 1);
+    else
+        scheduler->tx_pulses = saturating_add_u64(scheduler->tx_pulses, 1);
+
+    return rx;
+}

--- a/ebpf/src/scheduler.h
+++ b/ebpf/src/scheduler.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_SCHEDULER_H
+#define UGREEN_SCHEDULER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+struct pulse_scheduler {
+    long double rx_credit;
+    long double tx_credit;
+    uint64_t rx_pulses;
+    uint64_t tx_pulses;
+};
+
+bool scheduler_choose_rx(struct pulse_scheduler *scheduler,
+                         uint64_t rx_bytes, uint64_t tx_bytes);
+
+#endif

--- a/ebpf/src/types.h
+++ b/ebpf/src/types.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0
+#ifndef UGREEN_TYPES_H
+#define UGREEN_TYPES_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define UGREEN_LED_COUNT 10
+#define UGREEN_DISK_COUNT 8
+#define UGREEN_LED_POWER 0
+#define UGREEN_LED_NETWORK 1
+#define UGREEN_LED_DISK_FIRST 2
+
+struct rgb {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+};
+
+static inline bool rgb_equal(struct rgb a, struct rgb b)
+{
+    return a.r == b.r && a.g == b.g && a.b == b.b;
+}
+
+#endif

--- a/ebpf/systemd/ugreen-ledd@.service
+++ b/ebpf/systemd/ugreen-ledd@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=UGREEN event-driven LED daemon for %I
+After=local-fs.target network.target
+Wants=network.target
+
+[Service]
+Type=simple
+ExecStartPre=/usr/sbin/modprobe i2c-dev
+ExecStart=/usr/bin/ugreen-ledd --bpf-object /usr/lib/ugreen-leds/ugreen_led.bpf.o -i %I
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/ebpf/tests/bpf_load_test.c
+++ b/ebpf/tests/bpf_load_test.c
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <bpf/libbpf.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    const char *path = argc > 1 ? argv[1] : "./ugreen_led.bpf.o";
+    struct bpf_object *object = bpf_object__open_file(path, NULL);
+    int error;
+
+    if (!object) {
+        error = -(errno ? errno : EIO);
+        fprintf(stderr, "open %s: %s\n", path, strerror(-error));
+        return 1;
+    }
+    error = bpf_object__load(object);
+    if (error < 0)
+        fprintf(stderr, "load %s: %s\n", path, strerror(-error));
+    bpf_object__close(object);
+    return error < 0;
+}

--- a/ebpf/tests/ugreen_ledd_test.c
+++ b/ebpf/tests/ugreen_ledd_test.c
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "config.h"
+#include "disk_layout.h"
+#include "scheduler.h"
+
+static void test_weighted_ratio(void)
+{
+    struct pulse_scheduler scheduler = {0};
+    unsigned rx = 0;
+    unsigned tx = 0;
+    unsigned i;
+
+    for (i = 0; i < 100; ++i) {
+        if (scheduler_choose_rx(&scheduler, 800, 200))
+            ++rx;
+        else
+            ++tx;
+    }
+    assert(rx == 80);
+    assert(tx == 20);
+}
+
+static void test_direction_change_without_idle(void)
+{
+    struct pulse_scheduler scheduler = {0};
+    unsigned i;
+
+    for (i = 0; i < 200; ++i)
+        (void)scheduler_choose_rx(&scheduler, 1000000, 1000);
+    assert(!scheduler_choose_rx(&scheduler, 1000, 1000000));
+}
+
+static void test_config_and_cli_precedence(void)
+{
+    static const char contents[] =
+        "NETDEV_EBPF_INTERVAL_MS=175\n"
+        "NETDEV_EBPF_PULSE_MS=61 # inline comment\n"
+        "COLOR_NETDEV_RX=\"1 2 3\"\n"
+        "COLOR_NETDEV_TX='4 5 6'\n"
+        "BRIGHTNESS_NETDEV_LED=77\n"
+        "DISK_EBPF_INTERVAL_MS=120\n"
+        "DISK_EBPF_HOLD_MS=350\n"
+        "DISK_EBPF_PULSE_MS=50\n"
+        "MAPPING_METHOD=serial\n"
+        "DISK_SERIAL=\"one two three\"\n"
+        "LED_INVERT=false\n"
+        "COLOR_DISK_HEALTH=\"10 20 30\"\n"
+        "COLOR_DISK_HEALTH_PER_DISK[disk2]=\"11 22 33\"\n"
+        "BRIGHTNESS_POWER=88\n"
+        "COLOR_POWER=\"40 50 60\"\n"
+        "BLINK_TYPE_POWER=\"breath 400 600\"\n";
+    char path[] = "/tmp/ugreen-ledd-config-XXXXXX";
+    struct config config;
+    char *argv[] = {
+        "ugreen-ledd-test", "--config", path, "-i", "test0",
+        "--interval-ms", "200", "--rx-color", "9,8,7",
+        "--disk-hold-ms", "500", NULL,
+    };
+    int fd = mkstemp(path);
+
+    assert(fd >= 0);
+    assert(write(fd, contents, sizeof(contents) - 1) ==
+           (ssize_t)(sizeof(contents) - 1));
+    assert(close(fd) == 0);
+
+    assert(config_parse_options(11, argv, &config) == 0);
+    assert(config.network_enabled);
+    assert(!strcmp(config.interface, "test0"));
+    assert(config.network_interval_ms == 200);
+    assert(config.network_pulse_ms == 61);
+    assert(config.network_brightness == 77);
+    assert(config.network_rx_color.r == 9 &&
+           config.network_rx_color.g == 8 &&
+           config.network_rx_color.b == 7);
+    assert(config.disk_interval_ms == 120);
+    assert(config.disk_hold_ms == 500);
+    assert(config.disk_pulse_ms == 50);
+    assert(config.disk_mapping == DISK_MAPPING_SERIAL);
+    assert(!strcmp(config.disk_serials[0], "one"));
+    assert(!strcmp(config.disk_serials[2], "three"));
+    assert(!config.disk_invert);
+    assert(config.disk_color.r == 10 && config.disk_color.g == 20 &&
+           config.disk_color.b == 30);
+    assert(!config.disk_color_set[0]);
+    assert(config.disk_color_set[1]);
+    assert(config_disk_color(&config, 1).r == 11 &&
+           config_disk_color(&config, 1).g == 22 &&
+           config_disk_color(&config, 1).b == 33);
+    assert(config.power_brightness == 88);
+    assert(config.power_color.r == 40 && config.power_color.g == 50 &&
+           config.power_color.b == 60);
+    assert(config.power_mode == POWER_MODE_BREATH);
+    assert(config.power_on_ms == 400 && config.power_off_ms == 600);
+    assert(unlink(path) == 0);
+}
+
+static void test_power_only_is_valid(void)
+{
+    struct config config;
+    char path[] = "/tmp/ugreen-ledd-empty-config-XXXXXX";
+    char *argv[] = {
+        "ugreen-ledd-test", "--config", path,
+        "--no-network", "--no-disks", NULL,
+    };
+    int fd = mkstemp(path);
+
+    assert(fd >= 0);
+    assert(close(fd) == 0);
+    assert(config_parse_options(5, argv, &config) == 0);
+    assert(config.power_enabled);
+    assert(!config.network_enabled);
+    assert(!config.disks_enabled);
+    assert(!config.disk_invert);
+    assert(unlink(path) == 0);
+}
+
+static void test_repository_config_is_accepted(void)
+{
+    struct config config;
+
+    config_set_defaults(&config);
+    assert(config_load_file("../scripts/ugreen-leds.conf", &config) == 0);
+    assert(config.disk_interval_ms == 100);
+    assert(config.disk_hold_ms == 200);
+    assert(config.disk_pulse_ms == 45);
+    assert(!config.disk_invert);
+    assert(!config.network_enabled);
+}
+
+static void test_dxp6800_layout(void)
+{
+    const char *product = "DXP6800 Pro";
+
+    assert(disk_layout_slot_count(product) == 6);
+    assert(disk_layout_hctl_slot(product, 6, "/devices/2:0:0:0") == 0);
+    assert(disk_layout_hctl_slot(product, 6, "/devices/5:0:0:0") == 3);
+    assert(disk_layout_hctl_slot(product, 6, "/devices/0:0:0:0") == 4);
+    assert(disk_layout_hctl_slot(product, 6, "/devices/1:0:0:0") == 5);
+    assert(disk_layout_ata_slot(product, 6, "/pci/ata3/host2") == 0);
+    assert(disk_layout_ata_slot(product, 6, "/pci/ata6/host5") == 3);
+    assert(disk_layout_ata_slot(product, 6, "/pci/ata1/host0") == 4);
+    assert(disk_layout_ata_slot(product, 6, "/pci/ata2/host1") == 5);
+}
+
+static void test_standard_layout(void)
+{
+    assert(disk_layout_slot_count("DXP4800 Pro") == 4);
+    assert(disk_layout_hctl_slot("DXP4800 Pro", 4, "3:0:0:0") == 3);
+    assert(disk_layout_ata_slot("DXP4800 Pro", 4,
+                                "/devices/ata2/host1") == 1);
+}
+
+int main(void)
+{
+    test_weighted_ratio();
+    test_direction_change_without_idle();
+    test_config_and_cli_precedence();
+    test_power_only_is_valid();
+    test_repository_config_is_accepted();
+    test_dxp6800_layout();
+    test_standard_layout();
+    return 0;
+}

--- a/scripts/ugreen-leds.conf
+++ b/scripts/ugreen-leds.conf
@@ -32,7 +32,7 @@ STANDBY_CHECK_INTERVAL=1
 # Invert LED behavior for all LEDs - disk and network (default: 0)
 # 0 = dark when inactive, light on activity (normal behavior)
 # 1 = light when inactive, dark on activity (inverted behavior)
-LED_INVERT=1
+LED_INVERT=0
 
 # The serial numbers of disks (used only when MAPPING_METHOD=serial)
 # You need to record them before inserting to your NAS, and the corresponding disk slots.
@@ -46,6 +46,17 @@ DISK_SERIAL="SN1 SN2 SN3 SN4"
 
 # The sleep time between two disk activities checks (default: 0.1 seconds)
 LED_REFRESH_INTERVAL=0.1
+
+# eBPF disk activity aggregation interval (default: 100 milliseconds)
+DISK_EBPF_INTERVAL_MS=100
+
+# Keep the MCU's hardware blink active this long after the last disk event
+# (default: 200 milliseconds)
+DISK_EBPF_HOLD_MS=200
+
+# Duration of the visible activity portion of the disk blink cycle
+# (default: 45 milliseconds)
+DISK_EBPF_PULSE_MS=45
 
 # brightness of disk LEDs, taking value from 1 to 255 (default: 255)
 BRIGHTNESS_DISK_LEDS="255"
@@ -96,6 +107,10 @@ CHECK_DISK_ONLINE_INTERVAL=5
 
 # =========== parameters of network activities monitoring ===========
 
+# Interface monitored by the unified eBPF daemon. Leave empty when supplying
+# -i/--interface on the command line or when network monitoring is unwanted.
+NETDEV_INTERFACE=""
+
 # Blink the netdev light when sending data (default: 1)
 NETDEV_BLINK_TX=1
 
@@ -104,6 +119,16 @@ NETDEV_BLINK_RX=1
 
 # A cycle of netdev blinking (default: 200 milliseconds)
 NETDEV_BLINK_INTERVAL=200
+
+# eBPF network LED sampling interval (default: 100 milliseconds)
+NETDEV_EBPF_INTERVAL_MS=100
+
+# eBPF network LED pulse width (default: 45 milliseconds)
+NETDEV_EBPF_PULSE_MS=45
+
+# eBPF receive and transmit pulse colors
+COLOR_NETDEV_RX="0 96 255"
+COLOR_NETDEV_TX="255 0 0"
 
 # color of the netdev under the normal state (for CHECK_LINK_SPEED=false)
 COLOR_NETDEV_NORMAL="255 165 0"
@@ -145,8 +170,8 @@ COLOR_NETDEV_GATEWAY_UNREACHABLE="255 0 0"
 
 # Blink settings for the power LED
 # * none: no blinking (default)
-# * breath <delay_on> <delay_off>: breathing blink
-# * blink <delay_on> <delay_off>: blinking
+# * breath <delay_on_ms> <delay_off_ms>: breathing blink
+# * blink <delay_on_ms> <delay_off_ms>: blinking
 BLINK_TYPE_POWER="none"
 
 # brighness of the power LED (default: 255)


### PR DESCRIPTION
This introduces a unified userspace and eBPF solution for managing the front-panel LEDs on UGREEN DXP systems without relying on the led-ugreen DKMS module. This has only been tested on a DXP4800 Pro so far. A DXP6800 Pro disk-bay layout is included, but has only been covered by a userspace unit test.

Unlike loading the out-of-tree DKMS module, loading the eBPF programs does not set the kernel's out-of-tree module taint flag or impact secure boot.

The userspace program, ugreen-ledd, loads and attaches the eBPF object with libbpf. It is responsible for all LED policy and hardware access:

- Own the LED MCU through one serialized I2C connection, validate its acknowledgements, retry transient failures, and cache applied state.
- Discover physical SATA disks and map them to front-panel bays using the ATA, HCTL, or serial methods. Update that mapping after hotplug.
- Populate the eBPF disk map and consume activity events from the shared ring buffer.
- Convert network samples into weighted RX and TX pulses, extend disk activity blinks, and apply the configured power LED state.

The eBPF object contains three programs:

- Programs 1 and 2 monitor ingress/egress paths (respectively) via TC classifiers to account for received/transmitted packet bytes.
- Program 3 attaches to block:block_rq_issue and observes requests issued to block devices. It ignores devices that userspace has not mapped to a disk bay.

The eBPF programs aggregate or rate-limit activity in the kernel. They send compact events to userspace through a shared BPF ring buffer. This avoids a userspace wakeup for every packet or block request and leaves the daemon asleep while the monitored devices are idle. This reduces CPU wakeups compared with periodic userspace polling.

This also includes configuration settings, per-interface systemd unit, build rules, documentation, userspace regression tests, and BPF verifier load test needed for this backend. The existing CLI and DKMS implementations remain available as separate alternatives.